### PR TITLE
Replace temp dir with the current working directory.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var path = require('path');
 var resolve = require('resolve');
 var options = require('./options');
 
@@ -39,7 +40,9 @@ module.exports = function (cwd, args) {
     return options.generateHelp() + '\n';
   }
   var engine = new cwdEslint.CLIEngine(translateOptions(currentOptions));
-  var report = engine.executeOnFiles(files);
+  var report = engine.executeOnFiles(files.map(function (file) {
+    return file.replace(path.dirname(file), cwd);
+  }));
   if (currentOptions.quiet) {
     report.results = cwdEslint.CLIEngine.getErrorResults(report.results);
   }


### PR DESCRIPTION
This fix allows ESLint plugins like [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to behave properly.

In the case of eslint-plugin-import, it needs the canonical path of the file to do its import resolving.
