### PR TITLE
Porting eslint's stdin logic to eslint_d

### DIFF
--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -31,7 +31,16 @@ if (cmd === 'start') {
   } else {
     var commands = ['stop', 'status', 'restart'];
     if (commands.indexOf(cmd) === -1) {
-      client.lint(process.argv.slice(2));
+      var concat = require('concat-stream');
+      var useStdIn = (process.argv.indexOf('--stdin') > -1);
+
+      if (useStdIn) {
+        process.stdin.pipe(concat({ encoding: 'string' }, function (text) {
+          client.lint(process.argv.slice(2), text);
+        }));
+      } else {
+        client.lint(process.argv.slice(2));
+      }
     } else {
       client[cmd](process.argv.slice(3));
     }

--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -31,10 +31,10 @@ if (cmd === 'start') {
   } else {
     var commands = ['stop', 'status', 'restart'];
     if (commands.indexOf(cmd) === -1) {
-      var concat = require('concat-stream');
       var useStdIn = (process.argv.indexOf('--stdin') > -1);
 
       if (useStdIn) {
+        var concat = require('concat-stream');
         process.stdin.pipe(concat({ encoding: 'string' }, function (text) {
           client.lint(process.argv.slice(2), text);
         }));

--- a/lib/client.js
+++ b/lib/client.js
@@ -43,8 +43,8 @@ exports.status = function () {
   });
 };
 
-exports.lint = function (args) {
-  if (!args.length) {
+exports.lint = function (args, text) {
+  if (!args.length && !text) {
     process.stdout.write('No files specified\n');
     return;
   }
@@ -58,7 +58,8 @@ exports.lint = function (args) {
     });
     socket.end(JSON.stringify({
       cwd: process.cwd(),
-      args: args
+      args: args,
+      text: text
     }));
   }
   connect(function (err, socket) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -25,7 +25,7 @@ function translateOptions(cliOptions) {
 
 var eslintMap = {};
 
-module.exports = function (cwd, args) {
+module.exports = function (cwd, args, text) {
   process.chdir(cwd);
   var cwdEslint = eslintMap[cwd];
   if (!cwdEslint) {
@@ -35,11 +35,17 @@ module.exports = function (cwd, args) {
   }
   var currentOptions = options.parse([0, 0].concat(args));
   var files = currentOptions._;
-  if (!files.length) {
+  var stdin = currentOptions.stdin;
+  if (!files.length && (!stdin || !text)) {
     return options.generateHelp() + '\n';
   }
   var engine = new cwdEslint.CLIEngine(translateOptions(currentOptions));
-  var report = engine.executeOnFiles(files);
+  var report;
+  if (stdin && text) {
+    report = engine.executeOnText(text, currentOptions.stdinFilename);
+  } else {
+    report = engine.executeOnFiles(files);
+  }
   if (currentOptions.quiet) {
     report.results = cwdEslint.CLIEngine.getErrorResults(report.results);
   }

--- a/lib/options.js
+++ b/lib/options.js
@@ -98,6 +98,20 @@ module.exports = optionator({
         'Pattern of files to ignore (in addition to those in .eslintignore)'
     },
     {
+      heading: 'Using stdin'
+    },
+    {
+      option: 'stdin',
+      type: 'Boolean',
+      default: 'false',
+      description: 'Lint code provided on <STDIN>'
+    },
+    {
+      option: 'stdin-filename',
+      type: 'String',
+      description: 'Specify filename to process STDIN as'
+    },
+    {
       heading: 'Handling warnings'
     },
     {

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,18 +22,19 @@ var server = net.createServer({
       server.close();
       return;
     }
-    var cwd, args;
+    var cwd, args, text;
     if (data.substring(0, 1) === '{') {
       var json = JSON.parse(data);
       cwd = json.cwd;
       args = json.args;
+      text = json.text;
     } else {
       var parts = data.split(' ');
       cwd = parts[0];
       args = parts.slice(1);
     }
     try {
-      con.write(linter(cwd, args));
+      con.write(linter(cwd, args, text));
     } catch (e) {
       con.write(e.toString() + '\n');
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/mantoni/eslint_d.js.git"
   },
   "dependencies": {
+    "concat-stream": "^1.5.1",
     "eslint": "^1.4.2",
     "optionator": "^0.5.0",
     "resolve": "^1.1.6"


### PR DESCRIPTION
Allows IDEs to pass in code via stdin. Fixes #13.