### PR TITLE
Add eslint.js for WebStorm compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ let g:syntastic_javascript_eslint_exec = 'eslint_d'
 
 Atom users will not gain any performance from this module as it already avoids starting a new node instance and uses the API directly (see [this AtomLinter issue](https://github.com/AtomLinter/linter-eslint/issues/215)).
 
+- __Webstorm__: Configure your IDE to point to the eslint_d package instead of ESLint.
+
+In the ESLint configuration dialog, under 'ESLint package', select your eslint_d package. 
+
+If you get the error "../bin/eslint.js" file not found, you are using an outdated version of eslint_d.
+
+
 If you're using `eslint_d` in any other editor, please tell me!
 
 ## Moar speed

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('./eslint_d');


### PR DESCRIPTION
By adding a symlink, we can take advantage of the eslint_d inside of the WebStorm IDE

This does not add eslint to the npm bin, but just make sure `eslint.js` exists for tools and plugins that look for it.

Add eslint_d to WebStorm's ESLint config
![WebStorm ESLint Config](https://cloud.githubusercontent.com/assets/1464035/11602524/c68ff9ee-9a8f-11e5-87b0-75d5ba865f41.png)

Without this patch, we get the following error.
![WebStorm Error Message](https://cloud.githubusercontent.com/assets/1464035/11602523/c68ef4ae-9a8f-11e5-855b-8a5300100995.png)

With the patch, the linter is faster than ever!