### PR TITLE
Add support for exit code on lint error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,11 @@ exports.lint = function (args, text) {
 
   function lint(socket) {
     socket.on('data', function (chunk) {
-      process.stdout.write(chunk);
+      if (chunk.toString() === '<<EXIT>>') {
+        process.exit(1);
+      } else {
+        process.stdout.write(chunk);
+      }
     });
     socket.on('end', function () {
       process.stdout.write('\n');

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -65,5 +65,9 @@ module.exports = function (cwd, args, text) {
     output += 'ESLint found too many warnings (maximum: '
      + currentOptions.maxWarnings + ').\n';
   }
-  return output;
+  if (report.errorCount) {
+    return [output, 1];
+  } else {
+    return [output, 0];
+  }
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,17 +34,21 @@ var server = net.createServer({
       args = parts.slice(1);
     }
     try {
-      var resultAndExitCode = linter(cwd, args, text);
+      var resultAndExitCode = linter(cwd, args, text)
       var result = resultAndExitCode[0];
       var exitCode = resultAndExitCode[1];
-      con.write(result);
-      if (exitCode !== 0) {
-        con.write('<<EXIT>>');
-      }
+      con.write(result, 'utf-8', function() {
+        setTimeout(function() {
+          if (exitCode !== 0) {
+            con.write('<<EXIT>>');
+          }
+          con.end();
+        }, 10);
+      });
     } catch (e) {
       con.write(e.toString() + '\n');
+      con.end();
     }
-    con.end();
   });
 });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,13 @@ var server = net.createServer({
       args = parts.slice(1);
     }
     try {
-      con.write(linter(cwd, args, text));
+      var resultAndExitCode = linter(cwd, args, text);
+      var result = resultAndExitCode[0];
+      var exitCode = resultAndExitCode[1];
+      con.write(result);
+      if (exitCode !== 0) {
+        con.write('<<EXIT>>');
+      }
     } catch (e) {
       con.write(e.toString() + '\n');
     }


### PR DESCRIPTION
Thanks for making this package, it greatly speeds up lint times!

I ran into an issue where the exit code that `eslint` returns for a given command is non-zero, but the same command with `eslint_d` returns zero.

Example:

```
# test with eslint
$ eslint_d stop; echo '}' | eslint --stdin; echo "exit code: $?"

<text>
  1:1  error  Parsing error: Unexpected token

✖ 1 problem (1 error, 0 warnings)...
exit code: 1
```

```
# test with eslint_d
$ eslint_d stop; echo '{' | eslint_d --stdin; echo "exit code: $?"

<text>
  1:1  error  Parsing error: Unexpected token

✖ 1 problem (1 error, 0 warnings)...
exit code: 0
```

I think that the exit code is one area where `eslint` and `eslint_d` might differ. I'm not overly familiar with sockets, but it seems like the code in this PR causes the exit code to correctly return 1 when there is an error, and otherwise exits with exit code 0.

Is this a change that you would find beneficial or that could be improved? Thanks!