### PR TITLE
update eslint to 2.2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,13 +62,10 @@ rules:
     radix: 2
     semi: [2, "always"]
     semi-spacing: 2
-    space-after-keywords: 2
-    space-before-blocks: 2
+    keyword-spacing: 2
     space-before-function-paren: [2, { anonymous: "always", named: "never" }]
-    space-before-keywords: 2
     space-in-parens: [2, "never"]
     space-infix-ops: 2
-    space-return-throw-case: 2
     space-unary-ops: 2
     strict: [2, "global"]
     wrap-iife: [2, "outside"]

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "eslint": "^2.2.0",
-    "optionator": "^0.6.0",
-    "resolve": "^1.1.6",
-    "supports-color": "^2.0.0"
+    "optionator": "^0.8.1",
+    "resolve": "^1.1.7",
+    "supports-color": "^3.1.2"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "eslint": "^1.4.2",
+    "eslint": "^2.2.0",
     "optionator": "^0.6.0",
     "resolve": "^1.1.6",
     "supports-color": "^2.0.0"


### PR DESCRIPTION
Hello.

Since eslint 2.0 was released the `keyword-spacing`  rule is now the standard.
Running the test with eslint installed globally will fail because of this rule.

Is this something you guys would be interested in updating, since it creates a dependency
on 2.0 and probably needs a major release of eslint_d ?

I can help with that if needed.

I just came across this issue because of using eslint_d as a sublime linter plugin on a new project and it failing.

