### PR TITLE
requre chalk in another try-catch

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -2,6 +2,7 @@
 
 var resolve = require('resolve');
 var options = require('./options');
+var path = require('path');
 
 function translateOptions(cliOptions, cwd) {
   return {
@@ -34,16 +35,18 @@ module.exports = function (cwd, args, text) {
   if (!cwdDeps) {
     cwdDeps = {};
     try {
-      cwdDeps.eslint = require(resolve.sync('eslint', { basedir: cwd }));
+      var eslintPath = resolve.sync('eslint', { basedir: cwd });
+
+      cwdDeps.eslint = require(eslintPath);
+      // use chalk from eslint
+      cwdDeps.chalk = require(resolve.sync('chalk', { basedir: path.dirname(eslintPath) }));
     } catch (e) {
       // module not found
-      cwdDeps.eslint = require('eslint');
-    }
-    try {
-      cwdDeps.chalk = require(resolve.sync('chalk', { basedir: cwd }));
-    } catch (e) {
-      // module not found
-      cwdDeps.chalk = require('chalk');
+      var eslintPath = resolve.sync('eslint');
+
+      cwdDeps.eslint = require(eslintPath);
+      // use chalk from eslint
+      cwdDeps.chalk = require(resolve.sync('chalk', { basedir: path.dirname(eslintPath) }));
     }
     eslintMap[cwd] = cwdDeps;
   }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -35,10 +35,14 @@ module.exports = function (cwd, args, text) {
     cwdDeps = {};
     try {
       cwdDeps.eslint = require(resolve.sync('eslint', { basedir: cwd }));
-      cwdDeps.chalk = require(resolve.sync('chalk', { basedir: cwd }));
     } catch (e) {
       // module not found
       cwdDeps.eslint = require('eslint');
+    }
+    try {
+      cwdDeps.chalk = require(resolve.sync('chalk', { basedir: cwd }));
+    } catch (e) {
+      // module not found
       cwdDeps.chalk = require('chalk');
     }
     eslintMap[cwd] = cwdDeps;


### PR DESCRIPTION
in the use case when eslint is installed locally with 3rd party
configurations, for example: eslint-config-airbnb. However chalk is not
installed locally, this will cause an exception and goes into the catch
clause and load eslint and chak from eslint_d.

Now eslint will not able to find eslint-config-airbnb which installed
locally.

I split the try-catch clause, so that eslint and chalk will be loaded
separately. Means eslint will be resolved from local, and whether there
is eslint at local, it does not effect the way how chalk will be loaded.