### PR TITLE
Remove espree as the default parser

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -43,7 +43,7 @@ module.exports = optionator({
     {
       option: 'parser',
       type: 'String',
-      default: 'espree',
+      default: '',
       description: 'Specify the parser to be used'
     },
     {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "eslint": "^2.2.0",
+    "eslint": "^2.10.2",
     "optionator": "^0.8.1",
     "resolve": "^1.1.7",
     "supports-color": "^3.1.2"


### PR DESCRIPTION
A [recent change](https://github.com/eslint/eslint/commit/bda5de56d13e5aea3857dd9c78d2edde59d3dffa) removed `espree` as the explicit default parser in `eslint` as it was causing issues with users using `babel-eslint` as their parser. Possibly related to https://github.com/mantoni/eslint_d.js/issues/21 and https://github.com/mantoni/eslint_d.js/issues/40.