### PR TITLE
Introduce security token and bind to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Available commands:
 
 Type `eslint_d --help` to see the supported `eslint` options.
 
-`eslint_d` will select a free port automatically and store the port number in
-`~/.eslint_d_port`.
+`eslint_d` will select a free port automatically and store the port number
+along with an access token in `~/.eslint_d`.
 
 ## Editor integration
 
@@ -83,7 +83,9 @@ the `eslint_d` server with netcat. This will also eliminate the node.js startup
 time.
 
 ```bash
-$ echo '. file.js' | nc localhost `cat ~/.eslint_d_port`
+$ PORT=`cat ~/.eslint_d | cut -d" " -f1`
+$ TOKEN=`cat ~/.eslint_d | cut -d" " -f2`
+$ echo "$TOKEN $PWD file.js" | nc localhost $PORT
 ```
 
 This runs `eslint` in under `50ms`!

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,10 +4,10 @@ var net = require('net');
 var portfile = require('./portfile');
 
 function connect(callback) {
-  var port = portfile.read();
-  if (port) {
-    var socket = net.connect(port, function () {
-      callback(null, socket);
+  var data = portfile.read();
+  if (data) {
+    var socket = net.connect(data.port, function () {
+      callback(null, socket, data.token);
     });
     socket.on('error', function () {
       callback('Could not connect');
@@ -18,12 +18,12 @@ function connect(callback) {
 }
 
 exports.stop = function (callback) {
-  connect(function (err, socket) {
+  connect(function (err, socket, token) {
     if (err) {
       process.stdout.write(err + '\n');
       return;
     }
-    socket.end('stop', function () {
+    socket.end(token + ' stop', function () {
       if (typeof callback === 'function') {
         callback();
       }
@@ -49,7 +49,7 @@ exports.lint = function (args, text) {
     return;
   }
 
-  function lint(socket) {
+  function lint(socket, token) {
     var buf = '';
     socket.on('data', function (chunk) {
       buf += chunk;
@@ -68,25 +68,25 @@ exports.lint = function (args, text) {
         }
       }
     });
-    socket.end(JSON.stringify({
+    socket.end(token + ' ' + JSON.stringify({
       cwd: process.cwd(),
       args: args,
       text: text
     }));
   }
-  connect(function (err, socket) {
+  connect(function (err, socket, token) {
     if (err) {
       require('./launcher')(function () {
-        connect(function (err, socket) {
+        connect(function (err, socket, token) {
           if (err) {
             process.stdout.write(err + '\n');
           } else {
-            lint(socket);
+            lint(socket, token);
           }
         });
       });
     } else {
-      lint(socket);
+      lint(socket, token);
     }
   });
 };

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -4,12 +4,12 @@ var net = require('net');
 var portfile = require('../lib/portfile');
 
 function check(callback) {
-  var port = portfile.read();
-  if (!port) {
+  var data = portfile.read();
+  if (!data) {
     callback(false);
     return;
   }
-  var socket = net.connect(port, function () {
+  var socket = net.connect(data.port, function () {
     socket.end();
     callback(true);
   });

--- a/lib/portfile.js
+++ b/lib/portfile.js
@@ -4,22 +4,25 @@
 var fs = require('fs');
 
 var homeEnv = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
-var portFile = process.env[homeEnv] + '/.eslint_d_port';
+var dataFile = process.env[homeEnv] + '/.eslint_d';
 
-exports.write = function (port) {
-  fs.writeFileSync(portFile, String(port));
+exports.write = function (port, token) {
+  fs.writeFileSync(dataFile, port + ' ' + token);
 };
 
 exports.read = function () {
-  if (fs.existsSync(portFile)) {
-    var data = fs.readFileSync(portFile, 'utf8');
-    return Number(data);
+  if (fs.existsSync(dataFile)) {
+    var data = fs.readFileSync(dataFile, 'utf8').split(' ');
+    return {
+      port: Number(data[0]),
+      token: data[1]
+    };
   }
   return null;
 };
 
 exports.unlink = function () {
-  if (fs.existsSync(portFile)) {
-    fs.unlinkSync(portFile);
+  if (fs.existsSync(dataFile)) {
+    fs.unlinkSync(dataFile);
   }
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,11 @@
 'use strict';
 
+var crypto = require('crypto');
 var net = require('net');
 var portfile = require('./portfile');
 var linter = require('./linter');
+
+var token = crypto.randomBytes(8).toString('hex');
 
 
 var server = net.createServer({
@@ -17,6 +20,12 @@ var server = net.createServer({
       con.end();
       return;
     }
+    var p = data.indexOf(' ');
+    if (p === -1 || data.substring(0, p) !== token) {
+      con.end();
+      return;
+    }
+    data = data.substring(p + 1);
     if (data === 'stop') {
       con.end();
       server.close();
@@ -42,9 +51,9 @@ var server = net.createServer({
   });
 });
 
-server.listen(function () {
+server.listen(0, '127.0.0.1', function () {
   var port = server.address().port;
-  portfile.write(port);
+  portfile.write(port, token);
 });
 
 process.on('exit', function () {


### PR DESCRIPTION
This PR introduces a security token that is generated on server startup and is stored along with the port number in `~/.eslint_d`. Each request has to prepend the token, separated by a blank from the remaining payload. Requests without a matching token will be ignored.

While this is a security fix, I am tempted to release this as a patch. However, at the same time this introduces a protocol break which will cause issues with [eslintme](https://github.com/ruyadorno/eslintme). Fortunately, eslintme did not upgrade to `3.x` or `4.x` yet, so it should not cause any damage. I don't know of anybody else using the wire protocol.

Please send your feedback on this @moll and @ruyadorno. Thanks.