### PR TITLE
Fix --fix-to-stdout with empty file

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -58,7 +58,7 @@ module.exports = function (cwd, args, text) {
   cwdDeps.chalk.enabled = currentOptions.color;
   var files = currentOptions._;
   var stdin = currentOptions.stdin;
-  if (!files.length && (!stdin || !text)) {
+  if (!files.length && (!stdin || typeof text != 'string')) {
     return options.generateHelp() + '\n';
   }
   var engine = new cwdDeps.eslint.CLIEngine(


### PR DESCRIPTION
Previously it printed the help message instead of nothing.

We may not even need the check because this function is typically called by eslint_d.js itself, but it doesn't hurt.