### PR TITLE
Make it possible to pipe a stream to netcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ time.
 $ PORT=`cat ~/.eslint_d | cut -d" " -f1`
 $ TOKEN=`cat ~/.eslint_d | cut -d" " -f2`
 $ echo "$TOKEN $PWD file.js" | nc localhost $PORT
+
+# You can also pipe a stream in with `--stdin`:
+cat file.js | cat <(echo "$TOKEN $PWD --stdin") - | nc localhost $PORT
 ```
 
 This runs `eslint` in under `50ms`!

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,6 +38,11 @@ var server = net.createServer({
       args = json.args;
       text = json.text;
     } else {
+      if (data.includes('\n')) {
+        var index = data.indexOf('\n');
+        text = data.slice(index + 1);
+        data = data.slice(0, index);
+      }
       var parts = data.split(' ');
       cwd = parts[0];
       args = parts.slice(1);


### PR DESCRIPTION
This lets you avoid using a temporary file with the netcat interface.