### PR TITLE
Add basic integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   ],
   "homepage": "https://github.com/mantoni/eslint_d.js",
   "scripts": {
-    "test": "eslint ."
+    "lint": "eslint bin lib",
+    "pretest": "npm run lint",
+    "test": "./test.sh"
   },
   "repository": {
     "type": "git",

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail # bash "strict mode"
+
+eslint=./bin/eslint.js
+file=./test/prettier.js
+
+$eslint stop
+$eslint start
+
+PORT=`cat ~/.eslint_d | cut -d" " -f1`
+TOKEN=`cat ~/.eslint_d | cut -d" " -f2`
+
+md5sum $file | grep 904306b7a51e4f634016cccea8924ea1 >/dev/null
+$eslint --fix-to-stdout --stdin < $file | md5sum | grep f75b2b44fd861a20b69f9a3e1960e419 >/dev/null

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+"use strict"
+
+require("./prettier_d")


### PR DESCRIPTION
(following up on https://github.com/mantoni/eslint_d.js/pull/67#issuecomment-295379736)

This is adapted from the tests [here], and simply ensures that eslint_d
reformats an improperly formatted file, using the eslint configuration
of this project.

[here]: https://github.com/josephfrazier/prettier_d.js/blob/master/test.sh