### PR TITLE
Eslint 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "eslint": "^3.0.0",
+    "eslint": "^3.0.0 || ^4.0.0",
     "optionator": "^0.8.1",
     "resolve": "^1.1.7",
     "supports-color": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "eslint": "^3.0.0 || ^4.0.0",
+    "eslint": "^4.0.0",
     "optionator": "^0.8.1",
     "resolve": "^1.1.7",
     "supports-color": "^3.1.2"


### PR DESCRIPTION
With deduping, both versions are supported for clients.

Tested by doing `yarn add simenb/eslint_d.js#patch-1 && yarn --force` and inspecting resulting yarn.lock with eslint@3 installed and eslint@4 installed