### PR TITLE
Force all open connections to close when the server is stopped

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,12 @@ var linter = require('./linter');
 
 var token = crypto.randomBytes(8).toString('hex');
 
+var openConnections = []
+
+function forceClose(con) {
+  con.write('Server is stopping...\n# exit 1');
+  con.end();
+}
 
 var server = net.createServer({
   allowHalfOpen: true
@@ -16,6 +22,7 @@ var server = net.createServer({
     data += chunk;
   });
   con.on('end', function () {
+    openConnections = openConnections.filter(c => c !== con);
     if (!data) {
       con.end();
       return;
@@ -29,6 +36,7 @@ var server = net.createServer({
     if (data === 'stop') {
       con.end();
       server.close();
+      openConnections.forEach(forceClose);
       return;
     }
     var cwd, args, text;
@@ -55,6 +63,10 @@ var server = net.createServer({
     con.end();
   });
 });
+
+server.on('connection', function (con) {
+  openConnections = openConnections.concat([con])
+})
 
 server.listen(0, '127.0.0.1', function () {
   var port = server.address().port;


### PR DESCRIPTION
This is a less graceful approach to stopping the server, but it allows for
editors to hold a connection open to make for an even faster response time.

I have a version of eslintd-fix in the works that uses this technique and
achieves fixes that are pretty close to as fast as atom/vscode are capable of
with their in process eslint.