### PR TITLE
fix(launcher): passthrough environment variables

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -38,6 +38,7 @@ function launch(callback) {
   var server = require.resolve('../lib/server');
   var child = spawn('node', [server], {
     detached: true,
+    env: process.env,
     stdio: ['ignore', 'ignore', 'ignore']
   });
   child.unref();


### PR DESCRIPTION
Rationale

Passthrough environment variables to the spawn process. This is the default behavior of `child_process.spawn` when `options` is undefined, see https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options.

The use case is we use environment variables to enforce a stricter eslint configuration on lint-staged.

```js
module.exports = {
  extends: process.env.ESLINT_ENV="production" ? "../.eslintrc.strict" : "./.eslintrc"
}
```