### PR TITLE
Connect to 127.0.0.1 instead of localhost

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,7 +9,7 @@ function connect(callback) {
       callback('Not running');
       return;
     }
-    var socket = net.connect(data.port, function () {
+    var socket = net.connect(data.port, '127.0.0.1', function () {
       callback(null, socket, data.token);
     });
     socket.on('error', function () {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -9,7 +9,7 @@ function check(callback) {
       callback(false);
       return;
     }
-    var socket = net.connect(data.port, function () {
+    var socket = net.connect(data.port, '127.0.0.1', function () {
       socket.end();
       callback(true);
     });


### PR DESCRIPTION
If `localhost` doesn't resolve to `127.0.0.1`, the client cannot connect
to the server. This issue arose in https://github.com/josephfrazier/prettier_d/pull/7,
and I ported the changes from there.