### PR TITLE
Fix color support

### DIFF
--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -34,6 +34,9 @@ if (cmd === 'start') {
       var useStdIn = (process.argv.indexOf('--stdin') > -1);
       var args = process.argv.slice(2);
 
+      // If color is not supported, pass the `--no-color` switch to eslint. We
+      // enforce color support in the daemon with `FORCE_COLOR=1` (see
+      // `launcher.js`).
       if (!require('supports-color')) {
         args.unshift('--no-color');
       }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -34,11 +34,15 @@ function wait(callback) {
 }
 
 function launch(callback) {
+  var env = Object.create(process.env);
+  // Force enable color support in `supports-color`. The client adds
+  // `--no-color` to disable color if not supported.
+  env.FORCE_COLOR = 1;
   var spawn = require('child_process').spawn;
   var server = require.resolve('../lib/server');
   var child = spawn('node', [server], {
     detached: true,
-    env: process.env,
+    env: env,
     stdio: ['ignore', 'ignore', 'ignore']
   });
   child.unref();


### PR DESCRIPTION
This fixes #88 by restoring color support. The CLI explicitly adds `--no-color` to the arguments passed to eslint if colors are not supported which leads me to belive that color support used to work. Therefore the simple trick to add `FORCE_COLOR=1` to the environment when launching background processes does the trick.

This can be verified by running `eslint_d file.js` to see colors and `eslint_d file.js | less` to see no colors.