### PR TITLE
Unlink portfile when can't connect to server

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -13,6 +13,7 @@ module.exports = function (callback) {
       callback(null, socket, config.token);
     });
     socket.once('error', () => {
+      portfile.unlink();
       process.exitCode = 1;
       callback('Could not connect');
     });


### PR DESCRIPTION
If another process or even the user kills the eslint_d process manually, the portfile stays created and prevents a new server from starting. To prevent this, when the server is unreachable it unlinks the portfile so it can create a new instance