### PR TITLE
Handle obsolete portfile

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -12,8 +12,15 @@ module.exports = function (callback) {
     const socket = net.connect(config.port, '127.0.0.1', () => {
       callback(null, socket, config.token);
     });
-    socket.once('error', () => {
-      process.exitCode = 1;
+    socket.once('error', (err) => {
+      if (err.code === 'ECONNREFUSED') {
+        portfile.unlink();
+        if (global.eslint_d_launching) {
+          process.exitCode = 1;
+        }
+      } else {
+        process.exitCode = 1;
+      }
       callback('Could not connect');
     });
   });

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -6,6 +6,10 @@ const connect = require('./connect');
 function wait(callback) {
   connect((err, socket, token) => {
     if (err) {
+      if (process.exitCode) {
+        callback(err);
+        return;
+      }
       setTimeout(() => {
         wait(callback);
       }, 100);

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -24,6 +24,10 @@ function wait(callback) {
 }
 
 function launch(callback) {
+  if (global.eslint_d_launching) {
+    throw new Error('Already launching');
+  }
+  global.eslint_d_launching = true;
   const env = Object.create(process.env);
   // Force enable color support in `supports-color`. The client adds
   // `--no-color` to disable color if not supported.


### PR DESCRIPTION
In case the `eslint_d` client cannot connect, unlink the port file and relaunch a new instance transparently. This also adds a safety check to make sure a single client never launches more than one instance.

Inspired by #95, this is a solution for #61.