### PR TITLE
Fix issue #101: Error: Cannot find module 'chalk' from '$PROJECT_DIR/node_modules/eslint/lib'

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const LRU = require('nanolru');
-const resolve = require('resolve');
+const resolver = require('./resolver');
 const options = require('./options');
 const path = require('path');
 
@@ -47,16 +47,16 @@ function fail(message) {
 function createCache(cwd) {
   let eslintPath;
   try {
-    eslintPath = resolve.sync('eslint', { basedir: cwd });
+    eslintPath = resolver.resolve('eslint', { paths: [cwd] });
   } catch (e) {
     // module not found
-    eslintPath = resolve.sync('eslint');
+    eslintPath = resolver.resolve('eslint');
   }
   return eslintCache.set(cwd, {
     eslint: require(eslintPath),
     // use chalk from eslint
-    chalk: require(resolve.sync('chalk', {
-      basedir: path.dirname(eslintPath)
+    chalk: require(resolver.resolve('chalk', {
+      paths: [path.dirname(eslintPath)]
     }))
   });
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.resolve = function (id, options) {
+  return require.resolve(id, options);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,11 +1341,6 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -1414,14 +1409,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
     },
     "resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "core_d": "^2.0.0",
     "eslint": "^7.3.0",
     "nanolru": "^1.0.0",
-    "optionator": "^0.9.1",
-    "resolve": "^1.17.0"
+    "optionator": "^0.9.1"
   },
   "files": [
     "bin",

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const resolve = require('resolve');
+const resolver = require('../lib/resolver');
 const semver = require('semver');
 const { assert, refute, sinon, match } = require('@sinonjs/referee-sinon');
 const linter = require('../lib/linter');
@@ -22,7 +22,7 @@ describe('linter', () => {
   describe('instance caching', () => {
 
     beforeEach(() => {
-      sinon.spy(resolve, 'sync');
+      sinon.spy(resolver, 'resolve');
     });
 
     it('reuses instance from cache', () => {
@@ -34,9 +34,9 @@ describe('linter', () => {
       assert.equals(linter.cache.length, 1);
       assert.same(cache1, cache2, 'Cache recreated');
       assert.same(cache1.eslint, cache2.eslint);
-      assert.calledTwice(resolve.sync);
-      assert.calledWithMatch(resolve.sync, 'eslint', { basedir: cwd });
-      assert.calledWith(resolve.sync, 'chalk');
+      assert.calledTwice(resolver.resolve);
+      assert.calledWithMatch(resolver.resolve, 'eslint', { paths: [cwd] });
+      assert.calledWith(resolver.resolve, 'chalk');
     });
 
     it('uses new instance for different directory', () => {
@@ -45,9 +45,9 @@ describe('linter', () => {
       linter.invoke(cwd2, ['--stdin'], '\'use strict\';');
 
       assert.equals(linter.cache.length, 2);
-      assert.callCount(resolve.sync, 4);
-      assert.calledWithMatch(resolve.sync, 'eslint', { basedir: cwd });
-      assert.calledWithMatch(resolve.sync, 'eslint', { basedir: cwd2 });
+      assert.callCount(resolver.resolve, 4);
+      assert.calledWithMatch(resolver.resolve, 'eslint', { paths: [cwd] });
+      assert.calledWithMatch(resolver.resolve, 'eslint', { paths: [cwd2] });
     });
 
     it('creates new instance if mtime is larger than first call', () => {
@@ -63,7 +63,7 @@ describe('linter', () => {
       assert.equals(linter.cache.length, 1);
       refute.same(cache1, cache2);
       refute.same(cache1.eslint, cache2.eslint, 'require.cache cleared');
-      assert.callCount(resolve.sync, 4);
+      assert.callCount(resolver.resolve, 4);
     });
 
     it('does not create new instance if mtime is lower than last call', () => {
@@ -85,7 +85,7 @@ describe('linter', () => {
       assert.equals(linter.cache.length, 1);
       assert.same(cache1, cache2);
       assert.same(cache2, cache3);
-      assert.callCount(resolve.sync, 2);
+      assert.callCount(resolver.resolve, 2);
     });
 
   });


### PR DESCRIPTION
The cause of this issue is that `browserify/resolve` doesn't fully comply with Node's module resolution algorithm. 

Changing `browserify/resolve` with Node's `require.resolve` function solves this issue but breaks tests because Sinon is not able to spy on `require.resolve`. In fact each module has its own `require.resolve` instance, therefore I see 3 options how to fix tests (I implemented the **1st one**):

1. Wrap `require.resolve` in a function in a separate module and import it. Spy with Sinon on this wrapper function in the same way as on `browserify/resolve`. Not very nice but easy and works well.
2. Export `linter`'s `require.resolve` and spy on it. Works only while `require.resolve` is not used during `linter` module loading. This is the case for the moment, so it will work, but could confuse in the future if `require.resolve` will be added somewhere in module loading phase. Also, adding testing code to production module looks ugly for me.
3. Redesign tests in such a way that spying on resolve function is not needed anymore. Maybe it could make solution nicer but requires quite big effort and good overview on the whole package implementation, so I will not do it myself.
