### PR TITLE
Use level property instead of enabled for chalk

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -85,7 +85,9 @@ exports.invoke = function (cwd, args, text, mtime) {
   cache.last_run = Date.now();
 
   const currentOptions = options.parse([0, 0].concat(args));
-  cache.chalk.enabled = currentOptions.color;
+  if (!currentOptions.color) {
+    cache.chalk.level = 0;
+  }
   const files = currentOptions._;
   const stdin = currentOptions.stdin;
   if (!files.length && (!stdin || typeof text !== 'string')) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -85,7 +85,7 @@ exports.invoke = function (cwd, args, text, mtime) {
   cache.last_run = Date.now();
 
   const currentOptions = options.parse([0, 0].concat(args));
-  if (!currentOptions.color) {
+  if (currentOptions.color === false) {
     cache.chalk.level = 0;
   }
   const files = currentOptions._;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -85,6 +85,7 @@ exports.invoke = function (cwd, args, text, mtime) {
   cache.last_run = Date.now();
 
   const currentOptions = options.parse([0, 0].concat(args));
+  cache.chalk.enabled = currentOptions.color;
   if (currentOptions.color === false) {
     cache.chalk.level = 0;
   } else {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -87,6 +87,8 @@ exports.invoke = function (cwd, args, text, mtime) {
   const currentOptions = options.parse([0, 0].concat(args));
   if (currentOptions.color === false) {
     cache.chalk.level = 0;
+  } else {
+    cache.chalk.level = undefined;
   }
   const files = currentOptions._;
   const stdin = currentOptions.stdin;

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -289,13 +289,17 @@ describe('linter', () => {
         it('enables color by default', () => {
           linter.invoke(cwd, ['--stdin'], '\'use strict\';');
 
-          assert.isTrue(linter.cache.get(cwd).chalk.enabled);
+          assert.isTrue(
+            linter.cache.get(cwd).chalk.enabled
+            && linter.cache.get(cwd).chalk.level !== 0);
         });
 
         it('disables color if --no-color is passed', () => {
           linter.invoke(cwd, ['--stdin', '--no-color'], '\'use strict\';');
 
-          assert.isFalse(linter.cache.get(cwd).chalk.enabled);
+          assert.isFalse(
+            linter.cache.get(cwd).chalk.enabled
+            && linter.cache.get(cwd).chalk.level !== 0);
         });
 
       });


### PR DESCRIPTION
chalk no longer uses `enabled` property since [v3.0.0](https://github.com/chalk/chalk/releases/tag/v3.0.0).
Therefore `--no-color` option is not working.

This suggestion lets eslint_d use `level` property instead, so the problem would be fixed.

Thank you.