### PR TITLE
Implement exit codes

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -314,6 +314,7 @@ exports.invoke = async function (cwd, args, text, mtime, callback) {
     try {
       await executeWithESLint(cache.eslint.ESLint, cwd, opts, text, callback);
     } catch (e) {
+      e.exitCode = 2;
       callback(e);
     }
     return;
@@ -321,6 +322,7 @@ exports.invoke = async function (cwd, args, text, mtime, callback) {
   try {
     executeWithCLIEngine(cache.eslint.CLIEngine, cwd, opts, text, callback);
   } catch (e) {
+    e.exitCode = 2;
     callback(e);
   }
 };

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -155,6 +155,35 @@ describe('linter', () => {
         }
       });
 
+      describe('exit code', () => {
+
+        if (semver.gte(semver.coerce(eslint_version), '6.0.0')) {
+          it('fails when linting nonexistent file and sets exit code to 2',
+            async () => {
+              await linter.invoke(dir, ['bad-filename'], '', 0, callback);
+
+              assert.calledOnceWith(callback, match({
+                exitCode: 2
+              }));
+            });
+        } else {
+          it('fails when using unspported option and sets exit code to 2',
+            async () => {
+              await linter.invoke(dir, [
+                '--resolve-plugins-relative-to', plugin_folder,
+                '-c', plugin_eslintrc,
+                fixture_es6, '-f', 'unix'
+              ], '', 0, callback);
+
+              assert.calledOnceWith(callback, match({
+                exitCode: 2
+              }));
+            });
+        }
+
+      });
+
+
       describe('single file', () => {
 
         it('succeeds on lib/linter.js', async () => {


### PR DESCRIPTION
First pass at resolving #155, but I've kept it minimal so I can clarify a point before making further changes. 

This implementation only handles errors thrown by `executeWithESLint` and `executeWithCLIEngine`, which solves my specific case (handling broken / invalid configuration files) but leaves a bunch of other errors that [will cause ESLint to exit with code 2](https://github.com/eslint/eslint/commit/e4c3b3c5616319b7105c840de6e724f73f558ae0). 

`executeWithESLint` and `executeWithCLIEngine` each have a few places where they call `callback` directly with an error message string as the first argument. Would it be viable to replace those callback invocations with thrown errors instead, or is there something I'm missing? 

Also, wrapping the body of `invoke` in a try / catch block would allow consolidating exit codes into one place and also allow handling errors from inside `invoke` by throwing them, such as [this --fix-to-stdout error](https://github.com/jose-elias-alvarez/eslint_d.js/blob/06f6b91c931005d52dcdbb23b64f1eb11caf19ce/lib/linter.js#L309). Is that an option?

Please let me know what you think about this point (or if I'm going completely in the wrong direction!). 