### PR TITLE
Support Passing Alternative Eslint Module Path

### DIFF
--- a/lib/eslint-path.js
+++ b/lib/eslint-path.js
@@ -2,14 +2,14 @@
 
 const resolver = require('./resolver');
 
-exports.resolve = function (cwd, eslintPath) {
-  if (!eslintPath) {
-    eslintPath = 'eslint';
+exports.resolve = function (cwd, eslint_path) {
+  if (!eslint_path) {
+    eslint_path = 'eslint';
   }
   try {
-    return resolver.resolve(eslintPath, { paths: [cwd] });
+    return resolver.resolve(eslint_path, { paths: [cwd] });
   } catch (e) {
     // module not found
-    return resolver.resolve(eslintPath);
+    return resolver.resolve(eslint_path);
   }
 };

--- a/lib/eslint-path.js
+++ b/lib/eslint-path.js
@@ -2,11 +2,14 @@
 
 const resolver = require('./resolver');
 
-exports.resolve = function (cwd) {
+exports.resolve = function (cwd, eslintPath) {
+  if (!eslintPath) {
+    eslintPath = 'eslint';
+  }
   try {
-    return resolver.resolve('eslint', { paths: [cwd] });
+    return resolver.resolve(eslintPath, { paths: [cwd] });
   } catch (e) {
     // module not found
-    return resolver.resolve('eslint');
+    return resolver.resolve(eslintPath);
   }
 };

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -300,7 +300,6 @@ exports.invoke = async function (cwd, args, text, mtime, callback) {
     ? options_eslint
     : options_cliengine;
   const opts = options.parse([0, 0].concat(args));
-
   cache.chalk.enabled = opts.color;
   if (opts.color === false) {
     cache.chalk.level = 0;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -84,13 +84,13 @@ function translateOptionsESLint(cliOptions, cwd) {
 
 const eslintCache = new LRU(10);
 
-function createCache(cwd) {
-  const eslintPath = eslint_path.resolve(cwd);
+function createCache(cwd, eslintPath) {
+  const absoluteEslintPath = eslint_path.resolve(cwd, eslintPath);
   return eslintCache.set(cwd, {
-    eslint: require(eslintPath),
+    eslint: require(absoluteEslintPath),
     // use chalk from eslint
     chalk: require(resolver.resolve('chalk', {
-      paths: [path.dirname(eslintPath)]
+      paths: [path.dirname(absoluteEslintPath)]
     }))
   });
 }
@@ -278,12 +278,16 @@ function executeWithCLIEngine(CLIEngine, cwd, opts, text, callback) {
 exports.invoke = async function (cwd, args, text, mtime, callback) {
   process.chdir(cwd);
 
+  // Parse options as eslint by default, just so we can get the eslint path if
+  // necessary
+  const optsForPath = options_eslint.parse([0, 0].concat(args));
+
   let cache = eslintCache.get(cwd);
   if (!cache) {
-    cache = createCache(cwd);
+    cache = createCache(cwd, optsForPath.eslintPath);
   } else if (mtime > cache.last_run) {
     clearRequireCache(cwd);
-    cache = createCache(cwd);
+    cache = createCache(cwd, optsForPath.eslintPath);
   }
   cache.last_run = Date.now();
 
@@ -291,6 +295,7 @@ exports.invoke = async function (cwd, args, text, mtime, callback) {
     ? options_eslint
     : options_cliengine;
   const opts = options.parse([0, 0].concat(args));
+
   cache.chalk.enabled = opts.color;
   if (opts.color === false) {
     cache.chalk.level = 0;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -84,13 +84,13 @@ function translateOptionsESLint(cliOptions, cwd) {
 
 const eslintCache = new LRU(10);
 
-function createCache(cwd, eslint_path) {
-  const absoluteEslintPath = eslint_path.resolve(cwd, eslint_path);
+function createCache(cwd, eslint_path_arg) {
+  const absolute_eslint_path = eslint_path.resolve(cwd, eslint_path_arg);
   return eslintCache.set(cwd, {
-    eslint: require(absoluteEslintPath),
+    eslint: require(absolute_eslint_path),
     // use chalk from eslint
     chalk: require(resolver.resolve('chalk', {
-      paths: [path.dirname(absoluteEslintPath)]
+      paths: [path.dirname(absolute_eslint_path)]
     }))
   });
 }
@@ -278,16 +278,21 @@ function executeWithCLIEngine(CLIEngine, cwd, opts, text, callback) {
 exports.invoke = async function (cwd, args, text, mtime, callback) {
   process.chdir(cwd);
 
-  // Parse options as eslint by default, just so we can get the eslint path if
-  // necessary
-  const optsForPath = options_eslint.parse([0, 0].concat(args));
+  let eslint_path_arg;
+  const eslint_path_arg_index = args.indexOf('--eslint-path');
+  if (eslint_path_arg_index !== -1) {
+    eslint_path_arg = args[eslint_path_arg_index].split('=')[1];
+    if (!eslint_path_arg) {
+      eslint_path_arg = args[eslint_path_arg_index + 1];
+    }
+  }
 
   let cache = eslintCache.get(cwd);
   if (!cache) {
-    cache = createCache(cwd, optsForPath.eslintPath);
+    cache = createCache(cwd, eslint_path_arg);
   } else if (mtime > cache.last_run) {
     clearRequireCache(cwd);
-    cache = createCache(cwd, optsForPath.eslintPath);
+    cache = createCache(cwd, eslint_path_arg);
   }
   cache.last_run = Date.now();
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -84,8 +84,8 @@ function translateOptionsESLint(cliOptions, cwd) {
 
 const eslintCache = new LRU(10);
 
-function createCache(cwd, eslintPath) {
-  const absoluteEslintPath = eslint_path.resolve(cwd, eslintPath);
+function createCache(cwd, eslint_path) {
+  const absoluteEslintPath = eslint_path.resolve(cwd, eslint_path);
   return eslintCache.set(cwd, {
     eslint: require(absoluteEslintPath),
     // use chalk from eslint

--- a/lib/options-cliengine.js
+++ b/lib/options-cliengine.js
@@ -58,6 +58,11 @@ module.exports = optionator({
         + 'should be resolved from, CWD by default '
         + '(required the ESLint@6.0.0 or later)'
     },
+    {
+      option: 'eslint-path',
+      type: 'path::String',
+      description: 'Specify the path to the eslint module to use',
+    },
 
     {
       heading: 'Specifying rules and plugins'

--- a/lib/options-eslint.js
+++ b/lib/options-eslint.js
@@ -59,6 +59,11 @@ module.exports = optionator({
         + 'should be resolved from, CWD by default '
         + '(required the ESLint@6.0.0 or later)'
     },
+    {
+      option: 'eslint-path',
+      type: 'path::String',
+      description: 'Specify the path to the eslint module to use',
+    },
 
     {
       heading: 'Specifying rules and plugins'

--- a/test/eslint-path-test.js
+++ b/test/eslint-path-test.js
@@ -11,28 +11,68 @@ describe('eslint-path', () => {
     sinon.restore();
   });
 
-  it('resolves eslint using the given cwd', () => {
-    sinon.replace(resolver, 'resolve', sinon.fake.returns('/some/eslint'));
+  describe('without eslintPath', () => {
 
-    const result = eslint_path.resolve('some/cwd');
+    it('resolves eslint using the given cwd', () => {
+      sinon.replace(resolver, 'resolve', sinon.fake.returns('/some/eslint'));
 
-    assert.calledOnceWith(resolver.resolve, 'eslint', { paths: ['some/cwd'] });
-    assert.equals(result, '/some/eslint');
+      const result = eslint_path.resolve('some/cwd');
+
+      assert.calledOnceWith(resolver.resolve, 'eslint', {
+        paths: ['some/cwd']
+      });
+      assert.equals(result, '/some/eslint');
+    });
+
+    it('resolves eslint without given cwd if that failed', () => {
+      sinon.replace(resolver, 'resolve', sinon.fake((_, options) => {
+        if (options) {
+          throw new Error('Module not found');
+        }
+        return '/some/eslint';
+      }));
+
+      const result = eslint_path.resolve('some/cwd');
+
+      assert.calledTwice(resolver.resolve);
+      assert.calledWith(resolver.resolve, 'eslint', { paths: ['some/cwd'] });
+      assert.calledWithExactly(resolver.resolve, 'eslint');
+      assert.equals(result, '/some/eslint');
+    });
+
   });
 
-  it('resolves eslint without given cwd if that failed', () => {
-    sinon.replace(resolver, 'resolve', sinon.fake((_, options) => {
-      if (options) {
-        throw new Error('Module not found');
-      }
-      return '/some/eslint';
-    }));
+  describe('with eslintPath', () => {
 
-    const result = eslint_path.resolve('some/cwd');
+    it('resolves eslint using the given cwd', () => {
+      sinon.replace(resolver, 'resolve',
+        sinon.fake.returns('/some/other-eslint-path'));
 
-    assert.calledTwice(resolver.resolve);
-    assert.calledWith(resolver.resolve, 'eslint', { paths: ['some/cwd'] });
-    assert.calledWithExactly(resolver.resolve, 'eslint');
-    assert.equals(result, '/some/eslint');
+      const result = eslint_path.resolve('some/cwd', './other-eslint-path');
+
+      assert.calledOnceWith(resolver.resolve, './other-eslint-path', {
+        paths: ['some/cwd']
+      });
+      assert.equals(result, '/some/other-eslint-path');
+    });
+
+    it('resolves eslint without given cwd if that failed', () => {
+      sinon.replace(resolver, 'resolve', sinon.fake((_, options) => {
+        if (options) {
+          throw new Error('Module not found');
+        }
+        return '/some/other-eslint-path';
+      }));
+
+      const result = eslint_path.resolve('some/cwd', './other-eslint-path');
+
+      assert.calledTwice(resolver.resolve);
+      assert.calledWith(resolver.resolve, './other-eslint-path', {
+        paths: ['some/cwd']
+      });
+      assert.calledWithExactly(resolver.resolve, './other-eslint-path');
+      assert.equals(result, '/some/other-eslint-path');
+    });
+
   });
 });

--- a/test/eslint-path-test.js
+++ b/test/eslint-path-test.js
@@ -11,7 +11,7 @@ describe('eslint-path', () => {
     sinon.restore();
   });
 
-  describe('without eslintPath', () => {
+  describe('without eslint_path', () => {
 
     it('resolves eslint using the given cwd', () => {
       sinon.replace(resolver, 'resolve', sinon.fake.returns('/some/eslint'));
@@ -42,7 +42,7 @@ describe('eslint-path', () => {
 
   });
 
-  describe('with eslintPath', () => {
+  describe('with eslint_path', () => {
 
     it('resolves eslint using the given cwd', () => {
       sinon.replace(resolver, 'resolve',

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -473,6 +473,18 @@ describe('linter', () => {
           });
         }
 
+        describe('--eslint-path', () => {
+
+          it('uses the passed in binary', async () => {
+            await linter.invoke(dir, [
+              '--eslint-path', './node_modules/eslint',
+              fixture_es6, '-f', 'unix'
+            ], '', 0, callback);
+
+            assert.calledOnceWith(callback, null, '');
+          });
+
+        });
       });
 
     });


### PR DESCRIPTION
Allow passing an alternative path to an eslint module using the `--eslint-path` option. This will make it easier to support different module resolution schemes, such as Yarn PnP.

I went ahead and added this to the parsed options, so that it will also be shown if a user makes a call to `eslint_d --help`. Since this option determines which version of eslint will be used, we don't really know whether or not to parse options for the legacy `CLIEngine` or the `ESLint` class. Since we're only looking for the presence of `--eslint-path`, this really shouldn't matter, but it does mean we end up parsing options twice.

Closes #174 