### PR TITLE
Support quotes when parsing --eslint-path

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -279,11 +279,16 @@ exports.invoke = async function (cwd, args, text, mtime, callback) {
   process.chdir(cwd);
 
   let eslint_path_arg;
-  const eslint_path_arg_index = args.indexOf('--eslint-path');
+  const eslint_path_arg_index = args.findIndex((arg) => {
+    return arg.startsWith('--eslint-path');
+  });
   if (eslint_path_arg_index !== -1) {
     eslint_path_arg = args[eslint_path_arg_index].split('=')[1];
     if (!eslint_path_arg) {
       eslint_path_arg = args[eslint_path_arg_index + 1];
+    }
+    if (/^(".*"|'.*')$/.test(eslint_path_arg)) {
+      eslint_path_arg = eslint_path_arg.slice(1, -1);
     }
   }
 

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -484,6 +484,15 @@ describe('linter', () => {
             assert.calledOnceWith(callback, null, '');
           });
 
+          it('uses the passed in binary with quotes', async () => {
+            await linter.invoke(dir, [
+              '--eslint-path="./node_modules/eslint"',
+              fixture_es6, '-f', 'unix'
+            ], '', 0, callback);
+
+            assert.calledOnceWith(callback, null, '');
+          });
+
         });
       });
 


### PR DESCRIPTION
Fixes #177 by supporting the following patterns when parsing `--eslint-path`:

1. `--eslint-path [path]`
1. `--eslint-path '[path]'`
1. `--eslint-path "[path]"`
1. `--eslint-path=[path]`
1. `--eslint-path='[path]'`
1. `--eslint-path="[path]"`

An ideal solution would be to use a more forgiving options parser than `optionator`, then pass the parsed options through a validator as a second step, but I didn't want to introduce that big of a change.