### PR TITLE
fix: resolve local only env

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ current working directories `node_modules` folder, then this version of eslint
 is going to be used. Otherwise, the version of eslint that ships with
 `eslint_d` is used as a fallback.
 
+It's possible to force `eslint_d` to only resolve local `eslint` by setting the
+`ESLINT_D_LOCAL_ONLY` environment variable to a truthy value (ie. `true` or `1`).
+
 To keep the memory footprint low, `eslint_d` keeps only the last 10 used
 instances in the internal [nanolru][] cache.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ is going to be used. Otherwise, the version of eslint that ships with
 `eslint_d` is used as a fallback.
 
 It's possible to force `eslint_d` to only resolve local `eslint` by setting the
-`ESLINT_D_LOCAL_ONLY` environment variable to a truthy value (ie. `true` or `1`).
+`ESLINT_D_LOCAL_ESLINT_ONLY` environment variable to a truthy value (ie. `true` or `1`).
 
 To keep the memory footprint low, `eslint_d` keeps only the last 10 used
 instances in the internal [nanolru][] cache.

--- a/lib/eslint-path.js
+++ b/lib/eslint-path.js
@@ -9,7 +9,15 @@ exports.resolve = function (cwd, eslint_path) {
   try {
     return resolver.resolve(eslint_path, { paths: [cwd] });
   } catch (e) {
-    if (process.env.ESLINT_D_LOCAL_ONLY) {
+
+    let useOnlyLocal;
+    try {
+      useOnlyLocal = JSON.parse(process.env.ESLINT_D_LOCAL_ONLY);
+    } catch (parseError) {
+      useOnlyLocal = false;
+    }
+
+    if (useOnlyLocal) {
       return undefined;
     }
 

--- a/lib/eslint-path.js
+++ b/lib/eslint-path.js
@@ -12,7 +12,7 @@ exports.resolve = function (cwd, eslint_path) {
 
     let useOnlyLocal;
     try {
-      useOnlyLocal = JSON.parse(process.env.ESLINT_D_LOCAL_ONLY);
+      useOnlyLocal = JSON.parse(process.env.ESLINT_D_LOCAL_ESLINT_ONLY);
     } catch (parseError) {
       useOnlyLocal = false;
     }

--- a/lib/eslint-path.js
+++ b/lib/eslint-path.js
@@ -9,6 +9,10 @@ exports.resolve = function (cwd, eslint_path) {
   try {
     return resolver.resolve(eslint_path, { paths: [cwd] });
   } catch (e) {
+    if (process.env.ESLINT_D_LOCAL_ONLY) {
+      return undefined;
+    }
+
     // module not found
     return resolver.resolve(eslint_path);
   }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -305,6 +305,7 @@ exports.invoke = async function (cwd, args, text, hash, callback) {
     cache = createCache(cwd, eslint_path_arg);
   }
   if (!cache) {
+    callback(null);
     return;
   }
   cache.hash = hash;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -86,6 +86,11 @@ const eslintCache = new LRU(10);
 
 function createCache(cwd, eslint_path_arg) {
   const absolute_eslint_path = eslint_path.resolve(cwd, eslint_path_arg);
+
+  if (!absolute_eslint_path) {
+    return false;
+  }
+
   return eslintCache.set(cwd, {
     eslint: require(absolute_eslint_path),
     // use chalk from eslint
@@ -298,6 +303,9 @@ exports.invoke = async function (cwd, args, text, hash, callback) {
   } else if (hash !== cache.hash) {
     clearRequireCache(cwd);
     cache = createCache(cwd, eslint_path_arg);
+  }
+  if (!cache) {
+    return;
   }
   cache.hash = hash;
 

--- a/test/eslint-path-test.js
+++ b/test/eslint-path-test.js
@@ -4,7 +4,6 @@
 const { assert, sinon } = require('@sinonjs/referee-sinon');
 const resolver = require('../lib/resolver');
 const eslint_path = require('../lib/eslint-path');
-const { describe } = require('eslint/lib/rule-tester/rule-tester');
 
 describe('eslint-path', () => {
 
@@ -47,14 +46,11 @@ describe('eslint-path', () => {
     });
 
     describe('when ESLINT_D_LOCAL_ESLINT_ONLY is enabled', () => {
-      it('should not resolve a global prettier version', () => {
+      it('should not resolve a global eslint version', () => {
         process.env.ESLINT_D_LOCAL_ESLINT_ONLY = 1;
 
-        sinon.replace(resolver, 'resolve', sinon.fake((_, options) => {
-          if (options) {
-            throw new Error('Module not found');
-          }
-          return '/some/eslint';
+        sinon.replace(resolver, 'resolve', sinon.fake(() => {
+          throw new Error('Module not found');
         }));
 
         const result = eslint_path.resolve('some/cwd');

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -63,6 +63,22 @@ describe('linter', () => {
       refute.same(cache1.eslint, cache2.eslint, 'require.cache cleared');
       assert.callCount(resolver.resolve, 4);
     });
+
+    it('does not create cache and exits when not resolving eslint',
+      async () => {
+        sinon.replace(resolver, 'resolve', sinon.fake(() => undefined));
+
+        await linter.invoke(
+          cwd,
+          ['--stdin'],
+          '\'use strict\';', 1234, () => {}
+        );
+        const cache = linter.cache.get(cwd);
+
+        assert.equals(linter.cache.length, 0);
+        assert.isUndefined(cache);
+      }
+    );
   });
 
   describe('getStatus', () => {

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -66,15 +66,17 @@ describe('linter', () => {
 
     it('does not create cache and exits when not resolving eslint',
       async () => {
-        sinon.replace(resolver, 'resolve', sinon.fake(() => undefined));
+        const callback = sinon.fake();
+        sinon.replace(resolver, 'resolve', sinon.fake.returns(undefined));
 
         await linter.invoke(
           cwd,
           ['--stdin'],
-          '\'use strict\';', 1234, () => {}
+          '\'use strict\';', 1234, callback
         );
         const cache = linter.cache.get(cwd);
 
+        assert.calledOnce(callback);
         assert.equals(linter.cache.length, 0);
         assert.isUndefined(cache);
       }


### PR DESCRIPTION
This PR aims to provide a way to only resolve local `eslint` binaries and thus fixing https://github.com/mantoni/eslint_d.js/issues/180.

It simply checks for environment variables and returns early before resolving binary globally.

Suggestions for improvements on name is appreciated! 👍🏼 