### PR TITLE
Invalidate cache based on content hash rather than modification time

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -275,7 +275,7 @@ function executeWithCLIEngine(CLIEngine, cwd, opts, text, callback) {
 /*
  * The core_d service entry point.
  */
-exports.invoke = async function (cwd, args, text, mtime, callback) {
+exports.invoke = async function (cwd, args, text, hash, callback) {
   process.chdir(cwd);
 
   let eslint_path_arg;
@@ -295,11 +295,11 @@ exports.invoke = async function (cwd, args, text, mtime, callback) {
   let cache = eslintCache.get(cwd);
   if (!cache) {
     cache = createCache(cwd, eslint_path_arg);
-  } else if (mtime > cache.last_run) {
+  } else if (hash !== cache.hash) {
     clearRequireCache(cwd);
     cache = createCache(cwd, eslint_path_arg);
   }
-  cache.last_run = Date.now();
+  cache.hash = hash;
 
   const options = cache.eslint.ESLint
     ? options_eslint

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.1.1",
       "license": "MIT",
       "dependencies": {
-        "core_d": "^3.2.0",
+        "core_d": "^4.0.0",
         "eslint": "^7.3.0",
         "nanolru": "^1.0.0",
         "optionator": "^0.9.1"
@@ -500,9 +500,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/core_d": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/core_d/-/core_d-3.2.0.tgz",
-      "integrity": "sha512-waKkgHU2P19huhuMjCqCDWTYjxCIHoB+nnYjI7pVMUOC1giWxMNDrXkPw9QjWY+PWCFm49bD3wA/J+c7BGZ+og==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/core_d/-/core_d-4.0.0.tgz",
+      "integrity": "sha512-dBxd0Ocxj3D3K+rJxutTAZ9LQHkuMZoc9HPWYwYRYK7swou5wuIRXxgJ39YLNDvFHfHyV3JbxVYluF/AOhcRnw==",
       "dependencies": {
         "supports-color": "^8.1.0"
       }
@@ -2977,9 +2977,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core_d": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/core_d/-/core_d-3.2.0.tgz",
-      "integrity": "sha512-waKkgHU2P19huhuMjCqCDWTYjxCIHoB+nnYjI7pVMUOC1giWxMNDrXkPw9QjWY+PWCFm49bD3wA/J+c7BGZ+og==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/core_d/-/core_d-4.0.0.tgz",
+      "integrity": "sha512-dBxd0Ocxj3D3K+rJxutTAZ9LQHkuMZoc9HPWYwYRYK7swou5wuIRXxgJ39YLNDvFHfHyV3JbxVYluF/AOhcRnw==",
       "requires": {
         "supports-color": "^8.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/mantoni/eslint_d.js.git"
   },
   "dependencies": {
-    "core_d": "^3.2.0",
+    "core_d": "^4.0.0",
     "eslint": "^7.3.0",
     "nanolru": "^1.0.0",
     "optionator": "^0.9.1"


### PR DESCRIPTION
Fixes https://github.com/mantoni/eslint_d.js/issues/186. Depends on https://github.com/mantoni/core_d.js/pull/20.