### PR TITLE
Migrate to core_d v5 and implement common package manager file checks

### DIFF
--- a/lib/caches.js
+++ b/lib/caches.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const path = require('path');
+const LRU = require('nanolru');
+const resolver = require('./resolver');
+const eslint_path = require('./eslint-path');
+const files_hash = require('./files-hash');
+
+const lru_cache = new LRU(10);
+const check_files = [
+  'package.json',
+  'package-lock.json',
+  'npm-shrinkwrap.json',
+  'yarn.lock',
+  'pnpm-lock.yaml'
+];
+
+exports.lru_cache = lru_cache;
+
+exports.getCache = getCache;
+
+async function getCache(cwd, eslint_path_arg) {
+  let cache = lru_cache.get(cwd);
+  if (!cache) {
+    cache = createCache(cwd, eslint_path_arg);
+    if (cache) {
+      cache.filesChanged = await files_hash.filesHash(cwd, check_files);
+    }
+    return cache;
+  }
+  const { filesChanged } = cache;
+  if (filesChanged && await filesChanged()) {
+    clearRequireCache(cwd);
+    cache = createCache(cwd, eslint_path_arg);
+    cache.filesChanged = filesChanged;
+  }
+  return cache;
+}
+
+function createCache(cwd, eslint_path_arg) {
+  const absolute_eslint_path = eslint_path.resolve(cwd, eslint_path_arg);
+
+  if (!absolute_eslint_path) {
+    return null;
+  }
+
+  return lru_cache.set(cwd, {
+    eslint: require(absolute_eslint_path),
+    // use chalk from eslint
+    chalk: require(resolver.resolve('chalk', {
+      paths: [path.dirname(absolute_eslint_path)]
+    }))
+  });
+}
+
+function clearRequireCache(cwd) {
+  Object.keys(require.cache)
+    .filter(key => key.startsWith(cwd))
+    .forEach((key) => {
+      delete require.cache[key];
+    });
+}

--- a/lib/files-hash.js
+++ b/lib/files-hash.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+const crypto = require('crypto');
+
+exports.filesHash = filesHash;
+
+async function filesHash(cwd, files) {
+  const { existing, hash } = await getHash(
+    files.map((file) => path.join(cwd, file))
+  );
+  if (existing.length === 0) {
+    return null;
+  }
+
+  let last_hash = hash;
+  return async () => {
+    const { hash } = await getHash(existing);
+    if (last_hash === hash) {
+      return false;
+    }
+    last_hash = hash;
+    return true;
+  };
+}
+
+async function getHash(files) {
+  const results = await Promise.allSettled(
+    files.map((file) => fs.readFile(file))
+  );
+  const existing = [];
+  const hash = crypto.createHash('md5');
+  for (let i = 0; i < results.length; i++) {
+    const { status, value } = results[i];
+    if (status === 'fulfilled') {
+      existing.push(files[i]);
+      hash.update(value);
+    }
+  }
+  return { existing, hash: hash.digest('base64') };
+}

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -3,11 +3,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const LRU = require('nanolru');
-const resolver = require('./resolver');
-const eslint_path = require('./eslint-path');
 const options_cliengine = require('./options-cliengine');
 const options_eslint = require('./options-eslint');
+const caches = require('./caches');
 
 function translateOptionsCLIEngine(cliOptions, cwd) {
   return {
@@ -80,32 +78,6 @@ function translateOptionsESLint(cliOptions, cwd) {
     useEslintrc: cliOptions.eslintrc,
     cwd
   };
-}
-
-const eslintCache = new LRU(10);
-
-function createCache(cwd, eslint_path_arg) {
-  const absolute_eslint_path = eslint_path.resolve(cwd, eslint_path_arg);
-
-  if (!absolute_eslint_path) {
-    return false;
-  }
-
-  return eslintCache.set(cwd, {
-    eslint: require(absolute_eslint_path),
-    // use chalk from eslint
-    chalk: require(resolver.resolve('chalk', {
-      paths: [path.dirname(absolute_eslint_path)]
-    }))
-  });
-}
-
-function clearRequireCache(cwd) {
-  Object.keys(require.cache)
-    .filter(key => key.startsWith(cwd))
-    .forEach((key) => {
-      delete require.cache[key];
-    });
 }
 
 function countErrors(results) {
@@ -280,7 +252,7 @@ function executeWithCLIEngine(CLIEngine, cwd, opts, text, callback) {
 /*
  * The core_d service entry point.
  */
-exports.invoke = async function (cwd, args, text, hash, callback) {
+exports.invoke = async function (cwd, args, text, callback) {
   process.chdir(cwd);
 
   let eslint_path_arg;
@@ -297,18 +269,11 @@ exports.invoke = async function (cwd, args, text, hash, callback) {
     }
   }
 
-  let cache = eslintCache.get(cwd);
-  if (!cache) {
-    cache = createCache(cwd, eslint_path_arg);
-  } else if (hash !== cache.hash) {
-    clearRequireCache(cwd);
-    cache = createCache(cwd, eslint_path_arg);
-  }
+  const cache = await caches.getCache(cwd, eslint_path_arg);
   if (!cache) {
     callback(null);
     return;
   }
-  cache.hash = hash;
 
   const options = cache.eslint.ESLint
     ? options_eslint
@@ -351,13 +316,11 @@ exports.invoke = async function (cwd, args, text, hash, callback) {
   }
 };
 
-exports.cache = eslintCache;
-
 /*
  * The core_d status hook.
  */
 exports.getStatus = function () {
-  const { keys } = eslintCache;
+  const { keys } = caches.lru_cache;
   if (keys.length === 0) {
     return 'No instances cached.';
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.1.0",
       "license": "MIT",
       "dependencies": {
-        "core_d": "^4.0.0",
+        "core_d": "^5.0.1",
         "eslint": "^8.12.0",
         "nanolru": "^1.0.0",
         "optionator": "^0.9.1"
@@ -431,9 +431,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/core_d": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/core_d/-/core_d-4.0.0.tgz",
-      "integrity": "sha512-dBxd0Ocxj3D3K+rJxutTAZ9LQHkuMZoc9HPWYwYRYK7swou5wuIRXxgJ39YLNDvFHfHyV3JbxVYluF/AOhcRnw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/core_d/-/core_d-5.0.1.tgz",
+      "integrity": "sha512-37lZyhJY1hzgFbfU4LzY4zL09QPwPfV2W/3YBOtN7mkdvVaeP1OVnDZI6zxggtlPwG/BuE5wIr0xptlVJk5EPA==",
       "dependencies": {
         "supports-color": "^8.1.0"
       }
@@ -2644,9 +2644,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core_d": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/core_d/-/core_d-4.0.0.tgz",
-      "integrity": "sha512-dBxd0Ocxj3D3K+rJxutTAZ9LQHkuMZoc9HPWYwYRYK7swou5wuIRXxgJ39YLNDvFHfHyV3JbxVYluF/AOhcRnw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/core_d/-/core_d-5.0.1.tgz",
+      "integrity": "sha512-37lZyhJY1hzgFbfU4LzY4zL09QPwPfV2W/3YBOtN7mkdvVaeP1OVnDZI6zxggtlPwG/BuE5wIr0xptlVJk5EPA==",
       "requires": {
         "supports-color": "^8.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "url": "https://github.com/mantoni/eslint_d.js.git"
   },
   "dependencies": {
-    "core_d": "^4.0.0",
+    "core_d": "^5.0.1",
     "eslint": "^8.12.0",
     "nanolru": "^1.0.0",
     "optionator": "^0.9.1"

--- a/test/caches-test.js
+++ b/test/caches-test.js
@@ -1,0 +1,110 @@
+/*eslint-env mocha*/
+'use strict';
+
+const { assert, refute, sinon } = require('@sinonjs/referee-sinon');
+const eslint_path = require('../lib/eslint-path');
+const files_hash = require('../lib/files-hash');
+const { getCache, lru_cache } = require('../lib/caches');
+
+describe('test/caches', () => {
+  const cwd = process.cwd();
+
+  afterEach(() => {
+    lru_cache.clear();
+    sinon.restore();
+  });
+
+  it('calls eslint_path.resolve with cwd and eslint_path_arg', async () => {
+    sinon.replace(eslint_path, 'resolve', sinon.fake.returns(null));
+
+    await getCache(cwd, 'something');
+
+    assert.calledOnceWith(eslint_path.resolve, cwd, 'something');
+  });
+
+  it('calls filesHash with cwd and common package manager files', async () => {
+    sinon.replace(files_hash, 'filesHash', sinon.fake.resolves(() => {}));
+
+    await getCache(cwd);
+
+    assert.calledOnceWith(files_hash.filesHash, cwd, [
+      'package.json',
+      'package-lock.json',
+      'npm-shrinkwrap.json',
+      'yarn.lock',
+      'pnpm-lock.yaml'
+    ]);
+  });
+
+  it('creates a new cache with filesChanged', async () => {
+    const filesChanged = sinon.fake();
+    sinon.replace(files_hash, 'filesHash', sinon.fake.resolves(filesChanged));
+
+    const cache = await getCache(cwd);
+
+    refute.isNull(cache);
+    assert.same(lru_cache.get(cwd), cache);
+    assert.same(cache.filesChanged, filesChanged);
+  });
+
+  it('returns null if absolute eslint path cannot be resolved', async () => {
+    sinon.replace(files_hash, 'filesHash', sinon.fake());
+    sinon.replace(eslint_path, 'resolve', sinon.fake.returns(null));
+
+    const cache = await getCache('./some/path');
+
+    assert.isNull(cache);
+    refute.called(files_hash.filesHash);
+  });
+
+  it('returns same cache on second call if filesChanged is null', async () => {
+    sinon.replace(files_hash, 'filesHash', sinon.fake.resolves(null));
+
+    const cache_1 = await getCache(cwd);
+    const cache_2 = await getCache(cwd);
+
+    assert.same(cache_1, cache_2);
+  });
+
+  it('returns same cache on second call if filesChanged returns false',
+    async () => {
+      const filesChanged = sinon.fake.resolves(false);
+      sinon.replace(files_hash, 'filesHash', sinon.fake.resolves(filesChanged));
+
+      const cache_1 = await getCache(cwd);
+      const cache_2 = await getCache(cwd);
+
+      assert.calledOnce(filesChanged);
+      assert.same(cache_1, cache_2);
+    });
+
+  it('returns new cache on second call if filesChanged returns true',
+    async () => {
+      const filesChanged = sinon.fake.resolves(true);
+      sinon.replace(files_hash, 'filesHash', sinon.fake.resolves(filesChanged));
+
+      const cache_1 = await getCache(cwd);
+      const cache_2 = await getCache(cwd);
+
+      assert.calledOnce(filesChanged);
+      refute.same(cache_1, cache_2);
+      assert.same(cache_1.filesChanged, cache_2.filesChanged);
+    });
+
+  it('returns new cache on second call if cwd is different',
+    async () => {
+      sinon.replace(files_hash, 'filesHash',
+        sinon.fake(() => Promise.resolve(sinon.fake())));
+
+      const cache_1 = await getCache(cwd);
+      const cache_2 = await getCache('./other/path');
+
+      refute.same(cache_1, cache_2);
+      assert.calledTwice(files_hash.filesHash);
+      assert.calledWith(files_hash.filesHash, cwd);
+      assert.calledWith(files_hash.filesHash, './other/path');
+      refute.same(cache_1.filesChanged, cache_2.filesChanged);
+      refute.called(cache_1.filesChanged);
+      refute.called(cache_2.filesChanged);
+    });
+});

--- a/test/files-hash-test.js
+++ b/test/files-hash-test.js
@@ -1,0 +1,138 @@
+/*eslint-env mocha*/
+'use strict';
+
+const fs = require('fs').promises;
+const { assert, sinon } = require('@sinonjs/referee-sinon');
+const { filesHash } = require('../lib/files-hash');
+
+describe('files-hash', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('reads file contents of given files concurrently', () => {
+    sinon.replace(fs, 'readFile', sinon.fake.returns(sinon.promise()));
+
+    filesHash('some/path', ['a', 'b']);
+
+    assert.calledTwice(fs.readFile);
+    assert.calledWith(fs.readFile, 'some/path/a');
+    assert.calledWith(fs.readFile, 'some/path/b');
+  });
+
+  it('returns null if none of the files exist', async () => {
+    sinon.replace(fs, 'readFile', sinon.fake.rejects(new Error()));
+
+    const hasChanges = await filesHash('.', ['a', 'b']);
+
+    assert.isNull(hasChanges);
+  });
+
+  it('returns a function if one of the files exists', async () => {
+    sinon.replace(fs, 'readFile', sinon.fake((file) => {
+      if (file === 'a') {
+        return Promise.reject(new Error());
+      }
+      return Promise.resolve(Buffer.from('"use strict";'));
+    }));
+
+    const hasChanges = await filesHash('.', ['a', 'b']);
+
+    assert.isFunction(hasChanges);
+  });
+
+  it('reads the files again when invoking the returned function', async () => {
+    sinon.replace(fs, 'readFile',
+      sinon.fake.resolves(Buffer.from('"use strict;"')));
+
+    const hasChanges = await filesHash('some/dir', ['a', 'b']);
+    await hasChanges();
+
+    assert.callCount(fs.readFile, 4);
+    assert.equals(fs.readFile.args[0], ['some/dir/a']);
+    assert.equals(fs.readFile.args[1], ['some/dir/b']);
+    assert.equals(fs.readFile.args[2], ['some/dir/a']);
+    assert.equals(fs.readFile.args[3], ['some/dir/b']);
+  });
+
+  it('only reads the files again that succeeded initially', async () => {
+    sinon.replace(fs, 'readFile', sinon.fake((file) => {
+      if (file === 'a') {
+        return Promise.reject(new Error());
+      }
+      return Promise.resolve(Buffer.from('"use strict";'));
+    }));
+
+    const hasChanges = await filesHash('.', ['a', 'b']);
+    const changed = await hasChanges();
+
+    assert.isFalse(changed);
+    assert.callCount(fs.readFile, 3);
+    assert.equals(fs.readFile.args[0], ['a']);
+    assert.equals(fs.readFile.args[1], ['b']);
+    assert.equals(fs.readFile.args[2], ['b']);
+  });
+
+  it('returns false if the only file did not change', async () => {
+    sinon.replace(fs, 'readFile',
+      sinon.fake.resolves(Buffer.from('"use strict";')));
+
+    const hasChanges = await filesHash('.', ['a']);
+    const changed = await hasChanges();
+
+    assert.isFalse(changed);
+  });
+
+  it('returns false if none of the files changed', async () => {
+    sinon.replace(fs, 'readFile',
+      sinon.fake((file) => Promise.resolve(Buffer.from(file))));
+
+    const hasChanges = await filesHash('.', ['a', 'b']);
+    const changed = await hasChanges();
+
+    assert.isFalse(changed);
+  });
+
+  it(`returns false if none of the files changed and promises resolved in
+      different order`, async () => {
+    sinon.replace(fs, 'readFile', sinon.fake(() => sinon.promise()));
+
+    const files_hash_promise = filesHash('.', ['a', 'b']);
+    await fs.readFile.getCall(0).returnValue.resolve(Buffer.from('x'));
+    await fs.readFile.getCall(1).returnValue.resolve(Buffer.from('y'));
+
+    const hasChanges = await files_hash_promise;
+    const changed_promise = hasChanges();
+    await fs.readFile.getCall(3).returnValue.resolve(Buffer.from('y'));
+    await fs.readFile.getCall(2).returnValue.resolve(Buffer.from('x'));
+
+    assert.isFalse(await changed_promise);
+  });
+
+  it('returns true if the only file changed', async () => {
+    let calls = 0;
+    sinon.replace(fs, 'readFile', sinon.fake(() => {
+      return Promise.resolve(Buffer.from(String(calls++)));
+    }));
+
+    const hasChanges = await filesHash('.', ['a']);
+    const changed = await hasChanges();
+
+    assert.isTrue(changed);
+  });
+
+  it('returns true if one of the files changed', async () => {
+    let calls = 0;
+    sinon.replace(fs, 'readFile', sinon.fake((file) => {
+      if (file === 'a') {
+        return Promise.resolve(Buffer.from('"use strict";'));
+      }
+      return Promise.resolve(Buffer.from(String(calls++)));
+    }));
+
+    const hasChanges = await filesHash('.', ['a', 'b']);
+    const changed = await hasChanges();
+
+    assert.isTrue(changed);
+  });
+});


### PR DESCRIPTION
As discovered in #198, invalidating the `eslint_d` internal caches based on common package manager file content changes is broken. The feature has now been removed from `core_d` v5 (see mantoni/core_d.js#23).

This PR upgrades `core_d` to v5 and implements the file checks for common package manager file in `eslint_d` instead. It now actually checks the files in the `cwd` and further optimises performance by only checking files that existed when the cache was created.