### PR TITLE
Prevent unhandled promise exception

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -269,7 +269,14 @@ exports.invoke = async function (cwd, args, text, callback) {
     }
   }
 
-  const cache = await caches.getCache(cwd, eslint_path_arg);
+  let cache;
+  try {
+    cache = await caches.getCache(cwd, eslint_path_arg);
+  } catch (_) {
+    // Prevents unhandled promise exception when ESLint can not
+    // be resolved
+  }
+
   if (!cache) {
     callback(null);
     return;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -278,7 +278,7 @@ exports.invoke = async function (cwd, args, text, callback) {
   }
 
   if (!cache) {
-    callback(null, '');
+    callback('No ESLint found');
     return;
   }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -278,7 +278,7 @@ exports.invoke = async function (cwd, args, text, callback) {
   }
 
   if (!cache) {
-    callback(null);
+    callback(null, '');
     return;
   }
 

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -24,14 +24,10 @@ describe('linter', () => {
 
   describe('instance caching', () => {
 
-    beforeEach(() => {
-      sinon.spy(resolver, 'resolve');
-    });
-
     it('checks hash of common package manager files', async () => {
       sinon.replace(files_hash, 'filesHash',
         sinon.fake.resolves(() => Promise.resolve(false)));
-
+      sinon.spy(resolver, 'resolve');
       await linter.invoke(cwd, ['--stdin'], '\'use strict\';', () => {});
 
       assert.calledOnceWith(files_hash.filesHash, cwd, [
@@ -46,6 +42,7 @@ describe('linter', () => {
     it('reuses instance from cache', async () => {
       sinon.replace(files_hash, 'filesHash',
         sinon.fake.resolves(() => Promise.resolve(false)));
+      sinon.spy(resolver, 'resolve');
       await linter.invoke(cwd, ['--stdin'], '\'use strict\';', () => {});
       const cache1 = caches.lru_cache.get(cwd);
       await linter.invoke(cwd, ['--stdin'], '\'use strict\';', () => {});
@@ -62,6 +59,7 @@ describe('linter', () => {
     it('uses new instance for different directory', async () => {
       sinon.replace(files_hash, 'filesHash',
         sinon.fake.resolves(() => Promise.resolve(false)));
+      sinon.spy(resolver, 'resolve');
       const cwd2 = path.join(cwd, 'test');
       await linter.invoke(cwd, ['--stdin'], '\'use strict\';', () => {});
       await linter.invoke(cwd2, ['--stdin'], '\'use strict\';', () => {});
@@ -75,6 +73,7 @@ describe('linter', () => {
     it('creates new instance if hash differs from first call', async () => {
       sinon.replace(files_hash, 'filesHash',
         sinon.fake.resolves(() => Promise.resolve(true)));
+      sinon.spy(resolver, 'resolve');
       await linter.invoke(cwd, ['--stdin'], '\'use strict\';', () => {});
       const cache1 = caches.lru_cache.get(cwd);
 
@@ -102,6 +101,20 @@ describe('linter', () => {
         refute.called(files_hash.filesHash);
       }
     );
+
+    it('does not crash when ESLint resolver throws', async () => {
+      sinon.replace(files_hash, 'filesHash', sinon.fake());
+      const callback = sinon.fake();
+      sinon.replace(resolver, 'resolve', sinon.fake.throws());
+
+      await linter.invoke(cwd, ['--stdin'], '\'use strict\';', callback);
+      const cache = caches.lru_cache.get(cwd);
+
+      assert.calledOnce(callback);
+      assert.equals(caches.lru_cache.length, 0);
+      assert.isUndefined(cache);
+      refute.called(files_hash.filesHash);
+    });
   });
 
   describe('getStatus', () => {

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -115,6 +115,15 @@ describe('linter', () => {
       assert.isUndefined(cache);
       refute.called(files_hash.filesHash);
     });
+
+    it('does send error message when no ESLint found', async () => {
+      const callback = sinon.fake();
+      sinon.replace(resolver, 'resolve', sinon.fake.returns(undefined));
+
+      await linter.invoke(cwd, ['--stdin'], '\'use strict\';', callback);
+
+      assert.calledOnceWith(callback, 'No ESLint found');
+    });
   });
 
   describe('getStatus', () => {


### PR DESCRIPTION
At https://codesandbox.io/projects we are happily using this library, so thank you so much for the effort here 🙏 ❤️ 

What we have experienced though is that the process exits with an unhandled promise exception when it receives a message and no ESLint can be resolved. Looking at the code it makes perfect sense that this happens because indeed `getCache` will throw an error when no ESLint is found.

I assume this is not intended behaviour as this process just takes any path which might have ESLint available or not, the TCP server should never exit unless asked to do so.

I would also assume this is not discovered because most people using this library defaults to using the internal ESLint when none available. For us though it is crucial to only use ESLint if it is actually available.

We are currently using our forked version, but hope this is a helpful contribution to the library!

Again, thank you so much for the efforts here 😄 