### PR TITLE
feat: Add ESLINT_D_MAX_INSTANCES env variable. (#201) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ It's possible to force `eslint_d` to only resolve local `eslint` by setting the
 `ESLINT_D_LOCAL_ESLINT_ONLY` environment variable to a truthy value (ie. `true` or `1`).
 
 To keep the memory footprint low, `eslint_d` keeps only the last 10 used
-instances in the internal [nanolru][] cache.
+instances in the internal [nanolru][] cache.  To change the number of cached instances 
+set the `ESLINT_D_MAX_INSTANCES` environment variable to a positive integer.
 
 ## What if eslint or a plugin is updated?
 

--- a/lib/caches.js
+++ b/lib/caches.js
@@ -6,7 +6,25 @@ const resolver = require('./resolver');
 const eslint_path = require('./eslint-path');
 const files_hash = require('./files-hash');
 
-const lru_cache = new LRU(10);
+// Setup LRU cache + error checking user config.
+// 10 by default unless ESLINT_D_MAX_INSTANCES env variable is set.
+const { ESLINT_D_MAX_INSTANCES } = process.env;
+let maxInstances = ESLINT_D_MAX_INSTANCES
+  ? Number.parseInt(ESLINT_D_MAX_INSTANCES, 10)
+  : 10;
+
+if (Number.isInteger(maxInstances)) {
+  // eslint-disable-next-line max-len
+  console.error(new Error(`ESLINT_D_MAX_INSTANCES not a valid integer.  Instead found "${ESLINT_D_MAX_INSTANCES}".  Defaulting back to 10.`));
+  maxInstances = 10;
+}
+if (maxInstances <= 0) {
+  // eslint-disable-next-line max-len
+  console.error(new Error(`ESLINT_D_MAX_INSTANCES must be greater than 0.  Instead found "${ESLINT_D_MAX_INSTANCES}".  Defaulting back to 10.`));
+  maxInstances = 10;
+}
+const lru_cache = new LRU(maxInstances);
+
 const check_files = [
   'package.json',
   'package-lock.json',

--- a/lib/caches.js
+++ b/lib/caches.js
@@ -13,7 +13,7 @@ let maxInstances = ESLINT_D_MAX_INSTANCES
   ? Number.parseInt(ESLINT_D_MAX_INSTANCES, 10)
   : 10;
 
-if (Number.isInteger(maxInstances)) {
+if (!Number.isInteger(maxInstances)) {
   // eslint-disable-next-line max-len
   console.error(new Error(`ESLINT_D_MAX_INSTANCES not a valid integer.  Instead found "${ESLINT_D_MAX_INSTANCES}".  Defaulting back to 10.`));
   maxInstances = 10;


### PR DESCRIPTION
Hey I left this branch on my local machine and figured I'd just push it.  This resolves #201 by adding an environment variable to configure the max instances so it can be reduced/increased from 10.  
It just needs some help getting the error logging working.  I can't print to std out. Would you be able to help me with this?