### PR TITLE
feat: support eslint flat config on windows

### DIFF
--- a/lib/caches.js
+++ b/lib/caches.js
@@ -46,8 +46,7 @@ function createCache(cwd, eslint_path_arg) {
 
   // Use new ESLintFlatConfig
   if (process.env.ESLINT_USE_FLAT_CONFIG) {
-    absolute_eslint_path
-      = absolute_eslint_path.replace('/lib/api.js', '/lib/unsupported-api.js');
+    absolute_eslint_path = path.join(path.dirname(absolute_eslint_path), 'unsupported-api.js');
   }
   return lru_cache.set(cwd, {
     eslint: require(absolute_eslint_path),

--- a/lib/caches.js
+++ b/lib/caches.js
@@ -46,7 +46,8 @@ function createCache(cwd, eslint_path_arg) {
 
   // Use new ESLintFlatConfig
   if (process.env.ESLINT_USE_FLAT_CONFIG) {
-    absolute_eslint_path = path.join(path.dirname(absolute_eslint_path), 'unsupported-api.js');
+    absolute_eslint_path
+      = path.join(path.dirname(absolute_eslint_path), 'unsupported-api.js');
   }
   return lru_cache.set(cwd, {
     eslint: require(absolute_eslint_path),


### PR DESCRIPTION
I noticed that on Windows when trying to run `eslint_d` I was getting a type error saying something along th elines of eslint not being defined. I managed to track it down to the fact that in the PR [`absolute_eslint_path.replace()` was used](https://github.com/mantoni/eslint_d.js/pull/277/files#diff-6392a3a5106e8337ca42d13255dea882977d0c0a0f924663e17bb65acc84dc68R48-R51) to update the path for eslint.

This seems to not work on windows as the paths there use double backslash like `node_modules\\.pnpm\\eslint@8.54.0\\node_modules\\eslint\\lib\\api.js`.

In this PR I replaced it with `path.join` and `path.dirname`. Let me know if you have any questions or if there is something else that works too and you'd prefer me to use.