### PR TITLE
Override env core d options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ under the `XDG_RUNTIME_DIR` directory if this environment variable is
 defined. If the variable is not defined then the file is stored in the
 user's home directory.
 
+## Environment Variables
+
+- `CORE_D_TITLE`: Can be used to set the daemon process title. Defaults to
+  `eslint_d`.
+- `CORE_D_DOTFILE`: Can be used to set the name of the dotfile that stores the
+  server information. Defaults to `.eslint_d`.
+
+Note: Different CORE_D_TITLE and CORE_D_DOTFILE values will result in separte daemon processes.
+This is can be leveraged to run multiple instances of `eslint_d` for different projects, with different configurations for example.
+
 ## Editor integration
 
 ### Linting

--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -20,9 +20,9 @@ if (cmd === '-h' || cmd === '--help') {
   return;
 }
 
-process.env.CORE_D_TITLE = 'eslint_d';
-process.env.CORE_D_DOTFILE = '.eslint_d';
-process.env.CORE_D_SERVICE = require.resolve('../lib/linter');
+process.env.CORE_D_TITLE = process.env.OVERRIDE_CORE_D_TITLE || "eslint_d";
+process.env.CORE_D_DOTFILE = process.env.OVERRIDE_CORE_D_DOTFILE || ".eslint_d";
+process.env.CORE_D_SERVICE = require.resolve("../lib/linter");
 
 const core_d = require('core_d');
 

--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -20,8 +20,8 @@ if (cmd === '-h' || cmd === '--help') {
   return;
 }
 
-process.env.CORE_D_TITLE = process.env.OVERRIDE_CORE_D_TITLE || 'eslint_d';
-process.env.CORE_D_DOTFILE = process.env.OVERRIDE_CORE_D_DOTFILE || '.eslint_d';
+process.env.CORE_D_TITLE = process.env.CORE_D_TITLE || 'eslint_d';
+process.env.CORE_D_DOTFILE = process.env.CORE_D_DOTFILE || '.eslint_d';
 process.env.CORE_D_SERVICE = require.resolve('../lib/linter');
 
 const core_d = require('core_d');

--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -20,9 +20,9 @@ if (cmd === '-h' || cmd === '--help') {
   return;
 }
 
-process.env.CORE_D_TITLE = process.env.OVERRIDE_CORE_D_TITLE || "eslint_d";
-process.env.CORE_D_DOTFILE = process.env.OVERRIDE_CORE_D_DOTFILE || ".eslint_d";
-process.env.CORE_D_SERVICE = require.resolve("../lib/linter");
+process.env.CORE_D_TITLE = process.env.OVERRIDE_CORE_D_TITLE || 'eslint_d';
+process.env.CORE_D_DOTFILE = process.env.OVERRIDE_CORE_D_DOTFILE || '.eslint_d';
+process.env.CORE_D_SERVICE = require.resolve('../lib/linter');
 
 const core_d = require('core_d');
 


### PR DESCRIPTION
Regarding https://github.com/mantoni/eslint_d.js/issues/288 

This allows to use/override the environment variables `CORE_D_TITLE` and `CORE_D_DOTFILE` when running `eslint_d`, which is helpful for editor integrations to control the instances being run, when starting it as a child process for example and overriding the env.

I added some documentation. Let me know what else is needed.