### PR TITLE
Fix hash when changing directories

### DIFF
--- a/bin/eslint_d.js
+++ b/bin/eslint_d.js
@@ -25,7 +25,10 @@ const command = process.argv[2];
   }
 
   // eslint-disable-next-line prefer-const
-  let [config, hash] = await Promise.all([loadConfig(resolver), filesHash()]);
+  let [config, hash] = await Promise.all([
+    loadConfig(resolver),
+    filesHash(resolver.base)
+  ]);
   switch (command) {
     case 'start':
       if (config) {

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -11,12 +11,13 @@ const files = [
 ];
 
 /**
+ * @param {string} base
  * @returns {Promise<string>}
  */
-export async function filesHash() {
-  const cwd = process.cwd();
+export async function filesHash(base) {
+  const project = path.resolve(base, '../..');
   const results = await Promise.allSettled(
-    files.map((file) => fs.readFile(path.join(cwd, file)))
+    files.map((file) => fs.readFile(path.join(project, file)))
   );
   const hash = crypto.createHash('md5');
   for (const result of results) {

--- a/lib/hash.test.js
+++ b/lib/hash.test.js
@@ -4,24 +4,26 @@ import { filesHash } from './hash.js';
 
 describe('lib/hash', () => {
   context('filesHash', () => {
+    const base = 'some/dir/node_modules/eslint';
+    const cwd = process.cwd();
+
     it('reads files from cwd', () => {
-      sinon.replace(process, 'cwd', sinon.fake.returns('some/dir'));
       sinon.replace(fs, 'readFile', sinon.fake.returns(sinon.promise()));
 
-      filesHash();
+      filesHash(base);
 
       assert.callCount(fs.readFile, 5);
-      assert.calledWith(fs.readFile, 'some/dir/package.json');
-      assert.calledWith(fs.readFile, 'some/dir/package-lock.json');
-      assert.calledWith(fs.readFile, 'some/dir/npm-shrinkwrap.json');
-      assert.calledWith(fs.readFile, 'some/dir/yarn.lock');
-      assert.calledWith(fs.readFile, 'some/dir/pnpm-lock.yaml');
+      assert.calledWith(fs.readFile, `${cwd}/some/dir/package.json`);
+      assert.calledWith(fs.readFile, `${cwd}/some/dir/package-lock.json`);
+      assert.calledWith(fs.readFile, `${cwd}/some/dir/npm-shrinkwrap.json`);
+      assert.calledWith(fs.readFile, `${cwd}/some/dir/yarn.lock`);
+      assert.calledWith(fs.readFile, `${cwd}/some/dir/pnpm-lock.yaml`);
     });
 
     it('resolves with hash of all files', async () => {
       sinon.replace(fs, 'readFile', sinon.fake.resolves('file content'));
 
-      const promise = filesHash();
+      const promise = filesHash(base);
 
       await assert.resolves(promise, 'Jd1/4sH1IanXsNIo1eM+Jw==');
     });
@@ -29,7 +31,7 @@ describe('lib/hash', () => {
     it('resolves with null hash if none of the files can be resolved', async () => {
       sinon.replace(fs, 'readFile', sinon.fake.rejects());
 
-      const promise = filesHash();
+      const promise = filesHash(base);
 
       await assert.resolves(promise, '1B2M2Y8AsgTpgAmY7PhCfg==');
     });


### PR DESCRIPTION
The filenames where resolved relative to `process.cwd()` which means they're missing when calling `eslint_d` from a sub-directory. This would unnecessarily restart the server.

Fixes #296