### PR TITLE
Refactor handling of response's 'end' in forwarder

### DIFF
--- a/lib/forwarder.js
+++ b/lib/forwarder.js
@@ -7,6 +7,18 @@ import { removeConfig } from '../lib/config.js';
  * @import { Resolver} from '../lib/resolver.js'
  */
 
+/* Maximum number of characters of all eslint exit codes */
+const EXIT_CODE_MAX_LENGTH = 1;
+
+/* The string sent by our daemon upon termination */
+const DAEMON_EXIT_TOKEN = 'EXIT';
+
+const DAEMON_TERMINATION_CODE_MAX_LENGTH =
+  DAEMON_EXIT_TOKEN.length + EXIT_CODE_MAX_LENGTH;
+const DAEMON_TERMINATION_CODE_REGEXP = new RegExp(
+  `${DAEMON_EXIT_TOKEN}([0-9]{1,${EXIT_CODE_MAX_LENGTH}})`
+);
+
 /**
  * @param {Resolver} resolver
  * @param {Config} config
@@ -36,19 +48,38 @@ export async function forwardToDaemon(resolver, config) {
       let chunk = '';
       while ((chunk = socket.read()) !== null) {
         content += chunk;
-        if (content.length > 5) {
-          process.stdout.write(content.substring(0, content.length - 5));
-          content = content.substring(content.length - 5);
+        if (content.length > DAEMON_TERMINATION_CODE_MAX_LENGTH) {
+          const message_length =
+            content.length - DAEMON_TERMINATION_CODE_MAX_LENGTH;
+          // write everything we are sure doesn't contain the termination code:
+          process.stdout.write(content.substring(0, message_length));
+          // keep only what we haven't written yet:
+          content = content.substring(message_length);
         }
       }
     })
     .on('end', () => {
-      if (content.startsWith('EXIT')) {
-        process.exitCode = Number(content.slice(4));
-      } else {
+      // search the end of 'content' for the termination code:
+      const endOfContent = content.slice(-DAEMON_TERMINATION_CODE_MAX_LENGTH);
+      const match = endOfContent.match(DAEMON_TERMINATION_CODE_REGEXP);
+
+      if (!match) {
         process.stdout.write(content);
         console.error('eslint_d: unexpected response');
         process.exitCode = 1;
+        return;
+      }
+
+      // write everything but the termination code:
+      content = content.slice(
+        0,
+        -DAEMON_TERMINATION_CODE_MAX_LENGTH + (match.index || 0)
+      );
+
+      process.exitCode = Number(match[1]);
+
+      if (content) {
+        process.stdout.write(content);
       }
     })
     .on('error', async (err) => {

--- a/lib/forwarder.js
+++ b/lib/forwarder.js
@@ -8,7 +8,7 @@ import { removeConfig } from '../lib/config.js';
  */
 
 /* Maximum number of characters of all eslint exit codes */
-const EXIT_CODE_MAX_LENGTH = 1;
+const EXIT_CODE_MAX_LENGTH = 2;
 
 /* The string sent by our daemon upon termination */
 const DAEMON_EXIT_TOKEN = 'EXIT';

--- a/lib/forwarder.test.js
+++ b/lib/forwarder.test.js
@@ -85,7 +85,7 @@ describe('lib/forwarder', () => {
       assert.calledWith(socket.write, text);
     });
 
-    it('forwards socket response to stdout, except for the last 5 characters', () => {
+    it('forwards socket response to stdout', () => {
       const chunks = ['response ', 'from daemon'];
       sinon.replace(
         socket,
@@ -96,10 +96,12 @@ describe('lib/forwarder', () => {
 
       forwardToDaemon(resolver, config);
       socket.on.firstCall.callback(); // readable
+      socket.on.secondCall.callback(); // end
 
-      assert.calledTwice(process.stdout.write);
+      assert.calledThrice(process.stdout.write);
       assert.calledWith(process.stdout.write, 'resp');
       assert.calledWith(process.stdout.write, 'onse from d');
+      assert.calledWith(process.stdout.write, 'aemon');
     });
 
     it('handles EXIT0 from response', () => {

--- a/lib/forwarder.test.js
+++ b/lib/forwarder.test.js
@@ -99,9 +99,9 @@ describe('lib/forwarder', () => {
       socket.on.secondCall.callback(); // end
 
       assert.calledThrice(process.stdout.write);
-      assert.calledWith(process.stdout.write, 'resp');
-      assert.calledWith(process.stdout.write, 'onse from d');
-      assert.calledWith(process.stdout.write, 'aemon');
+      assert.calledWith(process.stdout.write, 'res');
+      assert.calledWith(process.stdout.write, 'ponse from ');
+      assert.calledWith(process.stdout.write, 'daemon');
     });
 
     it('handles EXIT0 from response', () => {
@@ -117,7 +117,8 @@ describe('lib/forwarder', () => {
       socket.on.firstCall.callback(); // readable
       socket.on.secondCall.callback(); // end
 
-      assert.calledOnceWith(process.stdout.write, 'response from daemon');
+      assert.calledWith(process.stdout.write, 'response from daemo');
+      assert.calledWith(process.stdout.write, 'n');
       assert.equals(process.exitCode, 0);
       refute.called(console.error);
     });
@@ -135,8 +136,27 @@ describe('lib/forwarder', () => {
       socket.on.firstCall.callback(); // readable
       socket.on.secondCall.callback(); // end
 
-      assert.calledWith(process.stdout.write, 'response from daemon');
+      assert.calledWith(process.stdout.write, 'response from daemo');
+      assert.calledWith(process.stdout.write, 'n');
       assert.equals(process.exitCode, 1);
+      refute.called(console.error);
+    });
+
+    it('handles EXIT12 from response', () => {
+      const chunks = ['response from daemonEXIT12'];
+      sinon.replace(
+        socket,
+        'read',
+        sinon.fake(() => (chunks.length ? chunks.shift() : null))
+      );
+      sinon.replace(process.stdout, 'write', sinon.fake());
+
+      forwardToDaemon(resolver, config);
+      socket.on.firstCall.callback(); // readable
+      socket.on.secondCall.callback(); // end
+
+      assert.calledWith(process.stdout.write, 'response from daemon');
+      assert.equals(process.exitCode, 12);
       refute.called(console.error);
     });
 
@@ -153,8 +173,9 @@ describe('lib/forwarder', () => {
       socket.on.firstCall.callback(); // readable
       socket.on.secondCall.callback(); // end
 
-      assert.calledWith(process.stdout.write, 'response ');
-      assert.calledWith(process.stdout.write, 'EXIT1 from daemon');
+      assert.calledWith(process.stdout.write, 'response');
+      assert.calledWith(process.stdout.write, ' EXIT1 from daemo');
+      assert.calledWith(process.stdout.write, 'n');
       assert.equals(process.exitCode, 1);
       refute.called(console.error);
     });
@@ -172,8 +193,8 @@ describe('lib/forwarder', () => {
       socket.on.firstCall.callback(); // readable
       socket.on.secondCall.callback(); // end
 
-      assert.calledWith(process.stdout.write, 'response from d');
-      assert.calledWith(process.stdout.write, 'aemon');
+      assert.calledWith(process.stdout.write, 'response from ');
+      assert.calledWith(process.stdout.write, 'daemon');
       assert.equals(process.exitCode, 1);
       assert.calledOnceWith(console.error, 'eslint_d: unexpected response');
     });

--- a/lib/forwarder.test.js
+++ b/lib/forwarder.test.js
@@ -138,6 +138,25 @@ describe('lib/forwarder', () => {
       refute.called(console.error);
     });
 
+    it('handles EXIT1 inside response', () => {
+      const chunks = ['response EXIT1', ' from daemonEXIT1'];
+      sinon.replace(
+        socket,
+        'read',
+        sinon.fake(() => (chunks.length ? chunks.shift() : null))
+      );
+      sinon.replace(process.stdout, 'write', sinon.fake());
+
+      forwardToDaemon(resolver, config);
+      socket.on.firstCall.callback(); // readable
+      socket.on.secondCall.callback(); // end
+
+      assert.calledWith(process.stdout.write, 'response ');
+      assert.calledWith(process.stdout.write, 'EXIT1 from daemon');
+      assert.equals(process.exitCode, 1);
+      refute.called(console.error);
+    });
+
     it('logs error and sets exitCode to 1 if response does not end with EXIT marker', () => {
       const chunks = ['response from daemon'];
       sinon.replace(


### PR DESCRIPTION
The only purpose of this refactoring is to simplify the implementation
of a new feature.

This refactoring propagates the limitation that the error code is a
string of only one character. This limitation is already present in
the code handling the 'readable' event.

It would be better to remove this limitation though but I wanted your
point of view on this first as it requires some more refactoring.