### PR TITLE
fix(resolver): eslint path detection not working on Windows

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
 
 /**
  * @typedef {Object} Resolver
@@ -16,7 +17,7 @@ export function createResolver() {
   let bundled = false;
   let path;
   try {
-    path = require.resolve('eslint', { paths: [process.cwd()] });
+    path = require.resolve('eslint/package.json', { paths: [process.cwd()] });
   } catch (err) {
     if (local === 'ignore') {
       return 'ignore';
@@ -26,11 +27,11 @@ export function createResolver() {
       return 'fail';
     }
     // Fallback to bundled eslint
-    path = require.resolve('eslint');
+    path = require.resolve('eslint/package.json');
     bundled = true;
   }
   return {
-    base: path.substring(0, path.lastIndexOf('/eslint/') + 7),
+    base: dirname(path),
     bundled,
     require
   };

--- a/lib/resolver.test.js
+++ b/lib/resolver.test.js
@@ -64,7 +64,7 @@ describe('lib/resolver', () => {
       assert.calledOnceWith(
         console.error,
         match(
-          "eslint_d: Failed to resolve eslint - Error: Cannot find module 'eslint'"
+          "eslint_d: Failed to resolve eslint - Error: Cannot find module 'eslint/package.json'"
         )
       );
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "mocha": "^10.7.0",
         "prettier": "^3.3.3",
         "typescript": "^5.5.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/parser": {


### PR DESCRIPTION
on Windows machines another path separator is used,
so instead of "/path/to/eslint/lib/eslint.js" we get
"C:\\path\\to\\eslint\\lib\\eslint.js".

Provided fix uses require.resolve of package.json which is
always at top-level and then passthrough it to dirname function,
which will return path to eslint package with correct path separators.
