### PR TITLE
chore: fix unit tests on Windows

### DIFF
--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import fs_promises from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { normalize, resolve } from 'node:path';
 import crypto from 'node:crypto';
 import net from 'node:net';
 import { assert, refute, match, sinon } from '@sinonjs/referee-sinon';
@@ -226,7 +226,7 @@ describe('lib/daemon', () => {
       assert.equals(process.title, 'eslint_d');
       assert.calledOnceWith(
         fs.readFile,
-        `${resolve(project)}/package.json`,
+        normalize(`${resolve(project)}/package.json`),
         'utf8'
       );
     });

--- a/lib/forwarder.test.js
+++ b/lib/forwarder.test.js
@@ -52,7 +52,7 @@ describe('lib/forwarder', () => {
 
       assert.calledOnceWith(
         socket.write,
-        `["token",${color_level},"the/cwd",["node","eslint_d"]]`
+        `["token",${color_level},"the/cwd",[${JSON.stringify(process.argv0)},"eslint_d"]]`
       );
       assert.calledOnce(socket.end);
     });
@@ -254,7 +254,7 @@ describe('lib/forwarder', () => {
         assert.calledThrice(socket.write);
         assert.calledWith(
           socket.write,
-          `["token",${color_level},"cwd",["node","eslint_d","--stdin","--fix-dry-run","--format","json","--other","--options"]]`
+          `["token",${color_level},"cwd",[${JSON.stringify(process.argv0)},"eslint_d","--stdin","--fix-dry-run","--format","json","--other","--options"]]`
         );
         assert.calledWith(socket.write, '\n');
         assert.calledWith(socket.write, 'text from stdin');

--- a/lib/hash.test.js
+++ b/lib/hash.test.js
@@ -1,3 +1,4 @@
+import { normalize } from 'node:path';
 import fs from 'node:fs/promises';
 import { assert, sinon } from '@sinonjs/referee-sinon';
 import { filesHash } from './hash.js';
@@ -13,11 +14,20 @@ describe('lib/hash', () => {
       filesHash(base);
 
       assert.callCount(fs.readFile, 5);
-      assert.calledWith(fs.readFile, `${cwd}/some/dir/package.json`);
-      assert.calledWith(fs.readFile, `${cwd}/some/dir/package-lock.json`);
-      assert.calledWith(fs.readFile, `${cwd}/some/dir/npm-shrinkwrap.json`);
-      assert.calledWith(fs.readFile, `${cwd}/some/dir/yarn.lock`);
-      assert.calledWith(fs.readFile, `${cwd}/some/dir/pnpm-lock.yaml`);
+      assert.calledWith(fs.readFile, normalize(`${cwd}/some/dir/package.json`));
+      assert.calledWith(
+        fs.readFile,
+        normalize(`${cwd}/some/dir/package-lock.json`)
+      );
+      assert.calledWith(
+        fs.readFile,
+        normalize(`${cwd}/some/dir/npm-shrinkwrap.json`)
+      );
+      assert.calledWith(fs.readFile, normalize(`${cwd}/some/dir/yarn.lock`));
+      assert.calledWith(
+        fs.readFile,
+        normalize(`${cwd}/some/dir/pnpm-lock.yaml`)
+      );
     });
 
     it('resolves with hash of all files', async () => {

--- a/lib/resolver.test.js
+++ b/lib/resolver.test.js
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { normalize, resolve } from 'node:path';
 import { assert, refute, match, sinon } from '@sinonjs/referee-sinon';
 import { createResolver } from './resolver.js';
 
@@ -16,7 +16,10 @@ describe('lib/resolver', () => {
 
       refute.isString(resolver);
       assert.isFalse(resolver['bundled']);
-      assert.equals(resolver['base'], `${test_dir}/node_modules/eslint`);
+      assert.equals(
+        resolver['base'],
+        normalize(`${test_dir}/node_modules/eslint`)
+      );
     });
   }
 


### PR DESCRIPTION
most of failures were related to "/" vs "\" in paths,
I've wrapped them in `normalize` from `node:path` module
to replace path delimiter character with proper one for
current OS.