### PR TITLE
Add test:coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage-reports

--- a/lib/launcher.test.js
+++ b/lib/launcher.test.js
@@ -190,13 +190,10 @@ describe('lib/launcher', () => {
   });
 
   context('unix: stopDaemon', () => {
-    if (os.platform() === 'win32') {
-      return;
-    }
-
     const config = { token: 'token', port: 123, pid: 456, hash: 'hash' };
 
     beforeEach(() => {
+      sinon.replace(os, 'platform', sinon.fake.returns('darwin'));
       sinon.replace(fs_promises, 'unlink', sinon.fake.resolves());
     });
 
@@ -257,14 +254,13 @@ describe('lib/launcher', () => {
   });
 
   context('win32: stopDaemon', () => {
-    if (os.platform() !== 'win32') {
-      return;
-    }
-
+    const sockets = [];
     let server;
     let config;
-    const sockets = [];
+
     beforeEach((done) => {
+      sinon.replace(os, 'platform', sinon.fake.returns('win32'));
+      sinon.replace(fs_promises, 'unlink', sinon.fake.resolves());
       server = net.createServer();
       server.on('connection', (socket) => sockets.push(socket));
       server.listen(0, '127.0.0.1', () => {
@@ -277,10 +273,6 @@ describe('lib/launcher', () => {
     afterEach((done) => {
       sockets.forEach((socket) => socket.destroy());
       server.close(done);
-    });
-
-    beforeEach(() => {
-      sinon.replace(fs_promises, 'unlink', sinon.fake.resolves());
     });
 
     context('without exception', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "husky": "^9.1.4",
         "lint-staged": "^15.2.8",
         "mocha": "^10.7.0",
+        "monocart-coverage-reports": "^2.10.9",
         "prettier": "^3.3.3",
         "typescript": "^5.5.4"
       },
@@ -45,6 +46,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.46.0",
@@ -190,6 +198,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jsdoc/salty": {
       "version": "0.2.8",
@@ -434,6 +449,32 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.4.0.tgz",
+      "integrity": "sha512-M0EUka6rb+QC4l9Z3T0nJEzNOO7JcoJlYMrBlyBCiFSXRyxjLKayd4TbQs2FDRWQU1h9FR7QVNHt+PEaoNL5rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -908,6 +949,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/console-grid": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.2.tgz",
+      "integrity": "sha512-ohlgXexdDTKLNsZz7DSJuCAwmRc8omSS61txOk39W3NOthgKGr1a1jJpZ5BCQe4PlrwMw01OvPQ1Bl3G7Y/uFg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -999,6 +1047,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/eight-colors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.0.tgz",
+      "integrity": "sha512-hVoK898cR71ADj7L1LZWaECLaSkzzPtqGXIaKv4K6Pzb72QgjLVsQaNI+ELDQQshzFvgp5xTPkaYkPGqw3YR+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
@@ -1658,6 +1713,23 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1938,6 +2010,13 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2183,6 +2262,58 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2698,6 +2829,29 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lz-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.1.0.tgz",
+      "integrity": "sha512-CMkfimAypidTtWjNDxY8a1bc1mJdyEh04V2FfEQ5Zh8Nx4v7k850EYa+dOWGn9hKG5xOyHP5MkuduAZCTHRvJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -2996,6 +3150,42 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/monocart-coverage-reports": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.10.9.tgz",
+      "integrity": "sha512-uFfqfm+py6H6qo7gl2gmqmaxB4Uzz1gvetsPtPwy2Mhmz2wSwGHnhESK2HXfMg0c/F15zLRn47lgrD2WcllP2Q==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "test"
+      ],
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "acorn": "^8.12.1",
+        "acorn-loose": "^8.4.0",
+        "acorn-walk": "^8.3.4",
+        "commander": "^12.1.0",
+        "console-grid": "^2.2.2",
+        "eight-colors": "^1.3.0",
+        "foreground-child": "^3.3.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.7",
+        "lz-utils": "^2.1.0",
+        "monocart-locator": "^1.0.2"
+      },
+      "bin": {
+        "mcr": "lib/cli.js"
+      }
+    },
+    "node_modules/monocart-locator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.2.tgz",
+      "integrity": "sha512-v8W5hJLcWMIxLCcSi/MHh+VeefI+ycFmGz23Froer9QzWjrbg4J3gFJBuI/T1VLNoYxF47bVPPxq8ZlNX4gVCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -3484,7 +3674,6 @@
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint .",
     "test": "mocha '**/*.test.js'",
     "test:integration": "mocha --bail --slow 1000 test/test.integration.js",
+    "test:coverage": "mcr --filter \"{'**/node_modules/**':false,'**/**':true}\" -r v8,console-details mocha '**/*.test.js'",
     "watch": "chokidar '**/*.js' -c 'npm t' --initial --silent",
     "prepare": "husky && sh scripts/install-fixture-deps.sh",
     "preversion": "npm run lint && npm run prettier:check && tsc && npm test && npm run test:integration",
@@ -49,6 +50,7 @@
     "husky": "^9.1.4",
     "lint-staged": "^15.2.8",
     "mocha": "^10.7.0",
+    "monocart-coverage-reports": "^2.10.9",
     "prettier": "^3.3.3",
     "typescript": "^5.5.4"
   },


### PR DESCRIPTION
Allow to see a coverage report with `npm run test:coverage`.

- Prints summary on the command line
- Generates a browsable v8 coverage report (`open coverage-reports/index.html`)