### PR TITLE
fix: unhandled 'error' event

### DIFF
--- a/lib/forwarder.js
+++ b/lib/forwarder.js
@@ -185,11 +185,11 @@ function connectToDaemon(config) {
   return new Promise((resolve, reject) => {
     const socket = net.connect(config.port, '127.0.0.1');
     socket
-      .on('connect', () => resolve(socket))
-      .on('connectionAttemptFailed', (err) => {
-        reject(err);
-        socket.end();
-      });
+      .on('connect', () => {
+        socket.off('error', reject);
+        resolve(socket);
+      })
+      .once('error', reject);
   });
 }
 


### PR DESCRIPTION
Replaced event listened in `connectToDaemon`

Fixes #319