### PR TITLE
Allow overriding eslint path with environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ All arguments are passed to eslint, except for the following commands:
 - `ESLINT_D_MISS` How to behave if local eslint is missing. "fallback" uses the
   bundled eslint (default). "fail" logs an error and exits with code 1.
   "ignore" silently exits with code 0.
+- `ESLINT_ROOT` Provide specific directory to search for `node_modules/eslint`.
+  Useful in monorepos where `node_modules` might be in a location other than
+  the project root
 
 ## Automatic fixing
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ All arguments are passed to eslint, except for the following commands:
 - `ESLINT_D_MISS` How to behave if local eslint is missing. "fallback" uses the
   bundled eslint (default). "fail" logs an error and exits with code 1.
   "ignore" silently exits with code 0.
-- `ESLINT_ROOT` Provide specific directory to search for `node_modules/eslint`.
+- `ESLINT_D_ROOT` Provide specific directory to search for `node_modules/eslint`.
   Useful in monorepos where `node_modules` might be in a location other than
-  the project root
+  the project root.
 
 ## Automatic fixing
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -21,5 +21,8 @@ Environment variables:
   ESLINT_D_MISS   How to behave if local eslint is missing. "fallback" uses the
                   bundled eslint (default). "fail" logs an error and exits with
                   code 1. "ignore" silently exits with code 0.
+  ESLINT_D_ROOT   Provide specific directory to search for node_modules/eslint.
+                  Useful in monorepos where node_modules might be in a location other than
+                  the project root.
 `);
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -16,8 +16,16 @@ export function createResolver() {
   const local = getLocal();
   let bundled = false;
   let path;
+
   try {
-    path = require.resolve('eslint/package.json', { paths: [process.cwd()] });
+    path = require.resolve('eslint/package.json', {
+      // Allow specific path to eslint with ESLINT_ROOT environment variable
+      // This is useful for monorepos where the location of node_modules can be more complex
+      paths: [
+        ...(process.env.ESLINT_ROOT ? [process.env.ESLINT_ROOT] : []),
+        process.cwd()
+      ]
+    });
   } catch (err) {
     if (local === 'ignore') {
       return 'ignore';

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -19,10 +19,10 @@ export function createResolver() {
 
   try {
     path = require.resolve('eslint/package.json', {
-      // Allow specific path to eslint with ESLINT_ROOT environment variable
+      // Allow specific path to eslint with ESLINT_D_ROOT environment variable
       // This is useful for monorepos where the location of node_modules can be more complex
       paths: [
-        ...(process.env.ESLINT_ROOT ? [process.env.ESLINT_ROOT] : []),
+        ...(process.env.ESLINT_D_ROOT ? [process.env.ESLINT_D_ROOT] : []),
         process.cwd()
       ]
     });

--- a/lib/resolver.test.js
+++ b/lib/resolver.test.js
@@ -102,4 +102,21 @@ describe('lib/resolver', () => {
       });
     });
   });
+
+  context('with override', () => {
+    beforeEach(() => {
+      process.env.ESLINT_ROOT = resolve('test/fixture/v8.0.x');
+    });
+
+    it('uses path from environment variable when present', () => {
+      const resolver = createResolver();
+
+      refute.isString(resolver);
+      assert.isFalse(resolver['bundled']);
+      assert.equals(
+        resolver['base'],
+        normalize(`${process.env.ESLINT_ROOT}/node_modules/eslint`)
+      );
+    });
+  });
 });

--- a/lib/resolver.test.js
+++ b/lib/resolver.test.js
@@ -105,7 +105,7 @@ describe('lib/resolver', () => {
 
   context('with override', () => {
     beforeEach(() => {
-      process.env.ESLINT_ROOT = resolve('test/fixture/v8.0.x');
+      process.env.ESLINT_D_ROOT = resolve('test/fixture/v8.0.x');
     });
 
     it('uses path from environment variable when present', () => {
@@ -115,7 +115,7 @@ describe('lib/resolver', () => {
       assert.isFalse(resolver['bundled']);
       assert.equals(
         resolver['base'],
-        normalize(`${process.env.ESLINT_ROOT}/node_modules/eslint`)
+        normalize(`${process.env.ESLINT_D_ROOT}/node_modules/eslint`)
       );
     });
   });


### PR DESCRIPTION
Fixes #242 

When `ESLINT_ROOT` is provided, attempt to resolve eslint from that path before checking `process.cwd`

This seemed like the simplest approach to me without re-working all of `ESLINT_D_MISS` behavior