### PR TITLE
Serialize Lint Requests

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -64,8 +64,15 @@ export function createService(resolver, token, shutdown) {
   }
   let debug_last = debug_global;
 
+  // The queue runs one lint request at a time. Each request redirects
+  // `process.stdout.write` and `process.stderr.write` to its socket. Concurrent
+  // lint requests can send output to the wrong socket.
+  let queue = Promise.resolve();
+
   return (con) => {
-    log('New connection');
+    if (debug_global) {
+      log('New connection');
+    }
     let content = '';
     con
       .setEncoding('utf8')
@@ -75,99 +82,144 @@ export function createService(resolver, token, shutdown) {
           content += chunk;
         }
       })
-      .on('end', async () => {
-        if (!content) {
-          log('Empty request');
-          con.end();
-          return;
+      .on('end', () => {
+        dispatchRequest(con, content);
+      })
+      .on('error', (e) => {
+        if (debug_global) {
+          log('Error from connection: %o', e);
         }
+      });
+  };
 
-        const newline = content.indexOf('\n');
-        let text = null;
-        if (newline !== -1) {
-          text = content.slice(newline + 1);
-          content = content.slice(0, newline);
-        }
-        const [request_token, command, color_level, cwd, argv, DEBUG] =
-          JSON.parse(content);
+  /**
+   * @param {Socket} con
+   * @param {string} content
+   */
+  function dispatchRequest(con, content) {
+    if (!content) {
+      if (debug_global) {
+        log('Empty request');
+      }
+      con.end();
+      return;
+    }
 
-        const debug_invoke = DEBUG || debug_global;
-        if (debug_invoke !== debug_last) {
-          if (debug_invoke === '') {
-            debug.disable();
-          } else {
-            debug.enable(debug_invoke);
-          }
-          debug_last = debug_invoke;
-        }
+    const newline = content.indexOf('\n');
+    let text = null;
+    if (newline !== -1) {
+      text = content.slice(newline + 1);
+      content = content.slice(0, newline);
+    }
+    let request;
+    try {
+      request = JSON.parse(content);
+    } catch (e) {
+      failRequest(con, e);
+      return;
+    }
+    const [request_token, command] = request;
 
-        if (!debug_global) {
-          process.stderr.write =
-            /** @type {function(Uint8Array | string): boolean} */ (
-              (chunk) => con.write(chunk)
-            );
-        }
+    if (request_token !== token) {
+      if (debug_global) {
+        log('Invalid token');
+      }
+      con.end();
+      return;
+    }
+    if (command !== LINT_COMMAND) {
+      if (debug_global) {
+        log('Executing command %s', command);
+      }
+      onCommand(con, command);
+      return;
+    }
 
-        log('Request: %o', {
-          request_token,
-          command,
-          color_level,
-          cwd,
-          argv,
-          DEBUG
-        });
-        if (text) {
-          log('Request stdin: %d', text.length);
-        }
+    queue = queue
+      .then(() => handleLintRequest(con, request, text))
+      .catch((e) => failRequest(con, e));
+  }
 
-        if (request_token !== token) {
-          log('Invalid token');
-          process.stderr.write = stderr_write;
-          con.end();
-          return;
+  /**
+   * @param {Socket} con
+   * @param {Array} request
+   * @param {string | null} text
+   */
+  async function handleLintRequest(con, request, text) {
+    const [request_token, command, color_level, cwd, argv, DEBUG] = request;
+    try {
+      const debug_invoke = DEBUG || debug_global;
+      if (debug_invoke !== debug_last) {
+        if (debug_invoke === '') {
+          debug.disable();
+        } else {
+          debug.enable(debug_invoke);
         }
-        if (command !== LINT_COMMAND) {
-          log('Executing command %s', command);
-          try {
-            onCommand(con, command);
-          } finally {
-            process.stderr.write = stderr_write;
-          }
-          return;
-        }
+        debug_last = debug_invoke;
+      }
 
-        if (chalk) {
-          chalk.level = color_level;
-        }
-        process.chdir(cwd);
-
-        process.stdout.write =
+      if (!debug_global) {
+        process.stderr.write =
           /** @type {function(Uint8Array | string): boolean} */ (
             (chunk) => con.write(chunk)
           );
+        log('New connection');
+      }
 
-        log('Executing eslint');
-        let code = 1;
-        try {
-          code = await eslint.execute(argv, text, true);
-        } catch (e) {
-          log('Error from eslint: %o', e);
-          con.write(String(e));
-        } finally {
-          log('Exit code from eslint: %d', code);
-          /* eslint-disable require-atomic-updates */
-          process.stdout.write = stdout_write;
-          process.stderr.write = stderr_write;
-          /* eslint-enable require-atomic-updates */
-          con.end(`EXIT${String(code).padStart(3, '0')}`);
-        }
-      })
-      .on('error', (e) => {
-        log('Error from connection: %o', e);
-        process.stdout.write = stdout_write;
-        process.stderr.write = stderr_write;
+      log('Request: %o', {
+        request_token,
+        command,
+        color_level,
+        cwd,
+        argv,
+        DEBUG
       });
-  };
+      if (text) {
+        log('Request stdin: %d', text.length);
+      }
+
+      if (chalk) {
+        chalk.level = color_level;
+      }
+      process.chdir(cwd);
+
+      process.stdout.write =
+        /** @type {function(Uint8Array | string): boolean} */ (
+          (chunk) => con.write(chunk)
+        );
+
+      log('Executing eslint');
+      let code = 1;
+      try {
+        code = await eslint.execute(argv, text, true);
+      } catch (e) {
+        log('Error from eslint: %o', e);
+        con.write(String(e));
+      }
+      log('Exit code from eslint: %d', code);
+      con.end(`EXIT${String(code).padStart(3, '0')}`);
+    } finally {
+      /* eslint-disable require-atomic-updates */
+      process.stdout.write = stdout_write;
+      process.stderr.write = stderr_write;
+      /* eslint-enable require-atomic-updates */
+    }
+  }
+
+  /**
+   * @param {Socket} con
+   * @param {unknown} error
+   */
+  function failRequest(con, error) {
+    if (debug_global) {
+      log('Unexpected error handling request: %o', error);
+    }
+    try {
+      con.end(`${String(error)}EXIT001`);
+    } catch {
+      con.destroy();
+    }
+  }
 
   /**
    * @param {Socket} con

--- a/lib/service.test.js
+++ b/lib/service.test.js
@@ -22,6 +22,9 @@ describe('lib/service', () => {
     const token = 'token';
     let shutdown_promise;
     let eslint_promise;
+    let eslint_promises;
+    /** @type {Error | null} */
+    let chdir_error;
     let service;
     let con;
 
@@ -34,9 +37,23 @@ describe('lib/service', () => {
 
     beforeEach(() => {
       eslint_promise = sinon.promise();
+      eslint_promises = [eslint_promise];
       shutdown_promise = sinon.promise();
-      sinon.replace(eslint, 'execute', sinon.fake.returns(eslint_promise));
-      sinon.replace(process, 'chdir', sinon.fake());
+      chdir_error = null;
+      sinon.replace(
+        eslint,
+        'execute',
+        sinon.fake(() => eslint_promises.shift())
+      );
+      sinon.replace(
+        process,
+        'chdir',
+        sinon.fake(() => {
+          if (chdir_error) {
+            throw chdir_error;
+          }
+        })
+      );
       sinon.replace(debug, 'enable', sinon.fake());
       sinon.replace(debug, 'disable', sinon.fake());
       service = createService(resolver, token, () =>
@@ -97,6 +114,11 @@ describe('lib/service', () => {
       con.emit('end');
     }
 
+    /** Waits for pending promise callbacks to run. */
+    function flush() {
+      return new Promise(setImmediate);
+    }
+
     it('immediately ends connection if no data is received', () => {
       con.emit('end');
 
@@ -131,6 +153,7 @@ describe('lib/service', () => {
 
     it('replaces stdout with a function that write to the socket', async () => {
       send(token, LINT_COMMAND, '3', '/', []);
+      await flush();
       process.stdout.write('test');
 
       await eslint_promise.resolve(0);
@@ -139,10 +162,71 @@ describe('lib/service', () => {
 
     it('replaces stderr with a function that write to the socket', async () => {
       send(token, LINT_COMMAND, '3', '/', []);
+      await flush();
       process.stderr.write('test');
 
       await eslint_promise.resolve(0);
       assert.calledOnceWith(con.write, 'test');
+    });
+
+    it('runs lint requests one at a time', async () => {
+      const first_promise = eslint_promise;
+      const first_con = con;
+      send(token, LINT_COMMAND, '3', '/', []);
+      await flush();
+
+      const second_promise = sinon.promise();
+      eslint_promises.push(second_promise);
+      connect();
+      const second_con = con;
+      send(token, LINT_COMMAND, '3', '/', []);
+      await flush();
+
+      assert.calledOnce(eslint.execute);
+      process.stdout.write('first');
+      assert.calledOnceWith(first_con.write, 'first');
+      refute.called(second_con.write);
+
+      await first_promise.resolve(0);
+      await flush();
+      assert.calledTwice(eslint.execute);
+      process.stdout.write('second');
+      assert.calledOnceWith(second_con.write, 'second');
+
+      await second_promise.resolve(0);
+      await flush();
+    });
+
+    it('handles shutdown while a lint request runs', async () => {
+      const lint_promise = eslint_promise;
+      send(token, LINT_COMMAND, '3', '/', []);
+      await flush();
+
+      connect();
+      send(token, SHUTDOWN_COMMAND, '3', '/', []);
+      await shutdown_promise;
+
+      assert.calledOnce(eslint.execute);
+      await lint_promise.resolve(0);
+      await flush();
+    });
+
+    it('ends the connection if request setup fails', async () => {
+      chdir_error = new Error('Directory not found');
+      send(token, LINT_COMMAND, '3', '/', []);
+      await flush();
+
+      refute.called(eslint.execute);
+      assert.calledOnceWith(con.end, 'Error: Directory not foundEXIT001');
+    });
+
+    it('ends the connection if the request is malformed', () => {
+      const chunks = ['{'];
+      sinon.replace(con, 'read', () => chunks.shift() || null);
+      con.emit('readable');
+      con.emit('end');
+
+      assert.calledOnce(con.end);
     });
 
     it('invokes eslint.execute with given args and no text', async () => {
@@ -163,6 +247,7 @@ describe('lib/service', () => {
       send(token, LINT_COMMAND, '3', '/', []);
 
       await eslint_promise.resolve(0);
+      await flush();
       refute.called(con.write);
       assert.calledOnceWith(con.end, 'EXIT000');
     });
@@ -171,6 +256,7 @@ describe('lib/service', () => {
       send(token, LINT_COMMAND, '3', '/', []);
 
       await eslint_promise.resolve(1);
+      await flush();
       refute.called(con.write);
       assert.calledOnceWith(con.end, 'EXIT001');
     });
@@ -179,6 +265,7 @@ describe('lib/service', () => {
       send(token, LINT_COMMAND, '3', '/', []);
 
       await eslint_promise.resolve(2);
+      await flush();
       refute.called(con.write);
       assert.calledOnceWith(con.end, 'EXIT002');
     });
@@ -187,6 +274,7 @@ describe('lib/service', () => {
       send(token, LINT_COMMAND, '3', '/', []);
 
       await eslint_promise.resolve(123);
+      await flush();
       refute.called(con.write);
       assert.calledOnceWith(con.end, 'EXIT123');
     });
@@ -195,6 +283,7 @@ describe('lib/service', () => {
       send(token, LINT_COMMAND, '3', '/', []);
 
       await eslint_promise.reject(new Error('Ouch!'));
+      await flush();
       assert.calledOnceWith(con.write, 'Error: Ouch!');
       assert.calledOnceWith(con.end, 'EXIT001');
     });


### PR DESCRIPTION
The service uses global `stdout` and `stderr` handlers. Concurrent lint requests can replace these handlers and send output to the wrong socket. The following changes have been made to resolve this:

- Run one lint request at a time to keep its output on the correct socket.
- Handle control commands outside the queue and close failed requests.
- Add tests for concurrent requests and request failures.
  - Tests: `npm test` and `npm run test:integration`.

Please let me know if anything requires adjustment; I was unable to find any contribution guidelines, but have endeavoured to respect existing code style and practices.